### PR TITLE
Couple of enhancements: configurable ssl_verify and returning vm details results as a list of dicts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,3 +18,7 @@
 
   ## V0.4.3
   Update nic actions to factor in Distributed Port Groups. When setting a network the DPG will be used over a standard port group of the same name.
+
+  ## V0.4.4
+  Added global ssl_verify configuration option to disable SSL certificate verification when connecting to vSphere servers.
+  Added custom JSON Encoder class to serialize VM summary (`vsphere.vm_hw_details_get`) output, hence, allowing results to be a list of dicts instead of strings. Makes it easier to access the results later in the workflows or action chains.

--- a/README.md
+++ b/README.md
@@ -8,20 +8,23 @@ You will need to specificy the details of the vcenter instance you will be conne
 You can specificy multiple environments using nested values
 
 ```yaml
-  vsphere:
-    dev:
-      host:
-      port:
-      user:
-      passwd:
-    staging:
-      host:
-      port:
-      user:
-      passwd:
+---
+ssl_verify: 
+vsphere:
+  dev:
+    host:
+    port:
+    user:
+    passwd:
+  staging:
+    host:
+    port:
+    user:
+    passwd:
 ```
 Note: To ensure backward compatability and ease for single environment use. If no vsphere value is passed to the actions it will look for v0.3 config.yaml structure:
 ```yaml
+  ssl_verify:
   host:
   port:
   user:

--- a/actions/vm_hw_details_get.py
+++ b/actions/vm_hw_details_get.py
@@ -18,6 +18,7 @@ from vmwarelib.serialize import MyJSONEncoder
 from vmwarelib.actions import BaseAction
 import json
 
+
 class GetVMDetails(BaseAction):
     def run(self, vm_ids, vm_names, vsphere=None):
         """
@@ -45,11 +46,11 @@ class GetVMDetails(BaseAction):
                 vm = inventory.get_virtualmachine(self.si_content, moid=vid)
                 if vm:
                     if vm.name not in results:
-                        results[vm.name] = json.loads(json.dumps(vm.summary,cls=MyJSONEncoder))
+                        results[vm.name] = json.loads(json.dumps(vm.summary, cls=MyJSONEncoder))
         if vm_names:
             for vm in vm_names:
                 vm = inventory.get_virtualmachine(self.si_content, name=vm)
                 if vm:
                     if vm.name not in results:
-                        results[vm.name] = json.loads(json.dumps(vm.summary,cls=MyJSONEncoder))
+                        results[vm.name] = json.loads(json.dumps(vm.summary, cls=MyJSONEncoder))
         return results

--- a/actions/vm_hw_details_get.py
+++ b/actions/vm_hw_details_get.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 from vmwarelib import inventory
+from vmwarelib.serialize import MyJSONEncoder
 from vmwarelib.actions import BaseAction
-
+import json
 
 class GetVMDetails(BaseAction):
     def run(self, vm_ids, vm_names, vsphere=None):
@@ -44,11 +45,11 @@ class GetVMDetails(BaseAction):
                 vm = inventory.get_virtualmachine(self.si_content, moid=vid)
                 if vm:
                     if vm.name not in results:
-                        results[vm.name] = str(vm.summary)
+                        results[vm.name] = json.loads(json.dumps(vm.summary,cls=MyJSONEncoder))
         if vm_names:
             for vm in vm_names:
                 vm = inventory.get_virtualmachine(self.si_content, name=vm)
                 if vm:
                     if vm.name not in results:
-                        results[vm.name] = str(vm.summary)
+                        results[vm.name] = json.loads(json.dumps(vm.summary,cls=MyJSONEncoder))
         return results

--- a/actions/vmwarelib/actions.py
+++ b/actions/vmwarelib/actions.py
@@ -15,12 +15,8 @@
 
 import atexit
 import eventlet
-
 from pyVim import connect
 from pyVmomi import vim  # pylint: disable-msg=E0611
-
-
-
 from st2actions.runners.pythonrunner import Action
 
 CONNECTION_ITEMS = ['host', 'port', 'user', 'passwd']
@@ -55,7 +51,6 @@ class BaseAction(Action):
                     pass
                 else:
                     ssl._create_default_https_context = _create_unverified_https_context
-
 
     def establish_connection(self, vsphere):
         self.si = self._connect(vsphere)

--- a/actions/vmwarelib/actions.py
+++ b/actions/vmwarelib/actions.py
@@ -18,6 +18,9 @@ import eventlet
 
 from pyVim import connect
 from pyVmomi import vim  # pylint: disable-msg=E0611
+
+
+
 from st2actions.runners.pythonrunner import Action
 
 CONNECTION_ITEMS = ['host', 'port', 'user', 'passwd']
@@ -39,6 +42,20 @@ class BaseAction(Action):
                     pass
                 else:
                     raise KeyError("Config.yaml Mising: %s" % (item))
+
+        if "ssl_verify" in config:
+            if not config['ssl_verify']:
+                import requests
+                requests.packages.urllib3.disable_warnings()
+                import ssl
+
+                try:
+                    _create_unverified_https_context = ssl._create_unverified_context
+                except AttributeError:
+                    pass
+                else:
+                    ssl._create_default_https_context = _create_unverified_https_context
+
 
     def establish_connection(self, vsphere):
         self.si = self._connect(vsphere)

--- a/actions/vmwarelib/serialize.py
+++ b/actions/vmwarelib/serialize.py
@@ -1,0 +1,31 @@
+import json
+from pyVmomi import vim  # pylint: disable-msg=E0611
+
+class MyJSONEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+        try:
+            return super(MyJSONEncoder, self).default(obj)
+
+        except TypeError:
+
+
+            if type(obj) in (vim.Network.Summary,
+                vim.Datastore.Summary,
+                vim.ClusterComputeResource.Summary,
+                vim.host.Summary,
+                vim.host.Summary.HardwareSummary,
+                vim.host.Summary.ConfigSummary,
+                vim.Network,
+                vim.AboutInfo,
+                vim.vm.Summary,
+                vim.vm.Summary.ConfigSummary,
+                vim.vm.Summary.StorageSummary,
+                vim.vm.Summary.GuestSummary,
+                vim.Datastore,
+                vim.vm.RuntimeInfo,
+                vim.vm.DeviceRuntimeInfo):
+                return obj.__dict__
+
+            # For anything else
+            return "__{}__".format(obj.__class__.__name__)

--- a/actions/vmwarelib/serialize.py
+++ b/actions/vmwarelib/serialize.py
@@ -10,22 +10,8 @@ class MyJSONEncoder(json.JSONEncoder):
 
         except TypeError:
 
-            if type(obj) in (vim.Network.Summary,
-                vim.Datastore.Summary,
-                vim.ClusterComputeResource.Summary,
-                vim.host.Summary,
-                vim.host.Summary.HardwareSummary,
-                vim.host.Summary.ConfigSummary,
-                vim.Network,
-                vim.AboutInfo,
-                vim.vm.Summary,
-                vim.vm.Summary.ConfigSummary,
-                vim.vm.Summary.StorageSummary,
-                vim.vm.Summary.GuestSummary,
-                vim.Datastore,
-                vim.vm.RuntimeInfo,
-                vim.vm.DeviceRuntimeInfo):
-                    return obj.__dict__
+            if type(obj) in (vim.Network.Summary, vim.Datastore.Summary, vim.ClusterComputeResource.Summary, vim.host.Summary, vim.host.Summary.HardwareSummary, vim.host.Summary.ConfigSummary, vim.Network, vim.AboutInfo, vim.vm.Summary, vim.vm.Summary.ConfigSummary, vim.vm.Summary.StorageSummary, vim.vm.Summary.GuestSummary, vim.Datastore, vim.vm.RuntimeInfo, vim.vm.DeviceRuntimeInfo):
+                return obj.__dict__
 
             # For anything else
             return "__{}__".format(obj.__class__.__name__)

--- a/actions/vmwarelib/serialize.py
+++ b/actions/vmwarelib/serialize.py
@@ -3,14 +3,19 @@ from pyVmomi import vim  # pylint: disable-msg=E0611
 
 
 class MyJSONEncoder(json.JSONEncoder):
-
     def default(self, obj):
         try:
             return super(MyJSONEncoder, self).default(obj)
 
         except TypeError:
 
-            if type(obj) in (vim.Network.Summary, vim.Datastore.Summary, vim.ClusterComputeResource.Summary, vim.host.Summary, vim.host.Summary.HardwareSummary, vim.host.Summary.ConfigSummary, vim.Network, vim.AboutInfo, vim.vm.Summary, vim.vm.Summary.ConfigSummary, vim.vm.Summary.StorageSummary, vim.vm.Summary.GuestSummary, vim.Datastore, vim.vm.RuntimeInfo, vim.vm.DeviceRuntimeInfo):
+            if type(obj) in (
+                    vim.Network.Summary, vim.Datastore.Summary, vim.ClusterComputeResource.Summary,
+                    vim.host.Summary, vim.host.Summary.HardwareSummary, vim.host.Summary.ConfigSummary,
+                    vim.Network, vim.AboutInfo, vim.vm.Summary, vim.vm.Summary.ConfigSummary,
+                    vim.vm.Summary.StorageSummary, vim.vm.Summary.GuestSummary, vim.Datastore,
+                    vim.vm.RuntimeInfo, vim.vm.DeviceRuntimeInfo
+            ):
                 return obj.__dict__
 
             # For anything else

--- a/actions/vmwarelib/serialize.py
+++ b/actions/vmwarelib/serialize.py
@@ -1,6 +1,7 @@
 import json
 from pyVmomi import vim  # pylint: disable-msg=E0611
 
+
 class MyJSONEncoder(json.JSONEncoder):
 
     def default(self, obj):
@@ -8,7 +9,6 @@ class MyJSONEncoder(json.JSONEncoder):
             return super(MyJSONEncoder, self).default(obj)
 
         except TypeError:
-
 
             if type(obj) in (vim.Network.Summary,
                 vim.Datastore.Summary,
@@ -25,7 +25,7 @@ class MyJSONEncoder(json.JSONEncoder):
                 vim.Datastore,
                 vim.vm.RuntimeInfo,
                 vim.vm.DeviceRuntimeInfo):
-                return obj.__dict__
+                    return obj.__dict__
 
             # For anything else
             return "__{}__".format(obj.__class__.__name__)

--- a/actions/vmwarelib/serialize.py
+++ b/actions/vmwarelib/serialize.py
@@ -10,8 +10,10 @@ class MyJSONEncoder(json.JSONEncoder):
         except TypeError:
 
             if type(obj) in (
-                    vim.Network.Summary, vim.Datastore.Summary, vim.ClusterComputeResource.Summary,
-                    vim.host.Summary, vim.host.Summary.HardwareSummary, vim.host.Summary.ConfigSummary,
+                    vim.Network.Summary, vim.Datastore.Summary,
+                    vim.ClusterComputeResource.Summary,
+                    vim.host.Summary, vim.host.Summary.HardwareSummary,
+                    vim.host.Summary.ConfigSummary,
                     vim.Network, vim.AboutInfo, vim.vm.Summary, vim.vm.Summary.ConfigSummary,
                     vim.vm.Summary.StorageSummary, vim.vm.Summary.GuestSummary, vim.Datastore,
                     vim.vm.RuntimeInfo, vim.vm.DeviceRuntimeInfo

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,8 @@
 ---
-  vsphere:
-    default:
-      host:
-      port:
-      user:
-      passwd:
+ssl_verify: yes
+vsphere:
+  default:
+    host:
+    port:
+    user:
+    passwd:

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: vsphere
 name : vsphere 
 description : st2 content pack containing vsphere integrations.
-version : 0.4.3
+version : 0.4.4
 author : Paul Mulvihill
 email : paul.mulvihill@pulsant.com

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,9 @@
 ---
 ref: vsphere
-name : vsphere 
-description : st2 content pack containing vsphere integrations.
-version : 0.4.4
-author : Paul Mulvihill
-email : paul.mulvihill@pulsant.com
+name: vsphere 
+description: st2 content pack containing vsphere integrations.
+version: 0.4.4
+author: Paul Mulvihill
+email: paul.mulvihill@pulsant.com
+contributors:
+  - Igor Cherkaev <emptywee@gmail.com>


### PR DESCRIPTION
This PR allows disabling verification of SSL cert when connecting to a vSphere Server. Most of them have a self-signed or outdated certs, so sometimes it's handy to be able to disable it. Can be enhanced to be configurable per vsphere server. Currently it's affecting all vsphere objects defined in the `config.yaml` file.
Also, when you query for hw details of some VM you'll get a list of objects instead of strings. Which is useful, since you can then access queried data as normal.