### PR TITLE
Added action that seeks MOID of object from name and type

### DIFF
--- a/actions/get_moid.py
+++ b/actions/get_moid.py
@@ -1,0 +1,62 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyVmomi import vim  # pylint: disable-msg=E0611
+
+from vmwarelib import inventory
+from vmwarelib.actions import BaseAction
+
+
+class GetMoid(BaseAction):
+    def run(self, object_names, object_type, vsphere=None):
+        """
+        Transform object_name and object_type to MOID (Managed Object Reference ID).
+
+        Args:
+        - object_name: name of object that is labeled to the target
+        - object_type: vimType of convert object
+
+        Returns:
+        - dict: key value pair of object_name and moid.
+        """
+
+        if object_type == 'VirtualMachine':
+            vimtype = vim.VirtualMachine
+        elif object_type == 'Network':
+            vimtype = vim.Network
+        elif object_type == 'Datastore':
+            vimtype = vim.Datastore
+        elif object_type == 'Datacenter':
+            vimtype = vim.Datacenter
+        elif object_type == 'Host':
+            vimtype = vim.HostSystem
+        else:
+            self.logger.warning("specified object_type ('%s') is not supported" % object_type)
+            return (False, {})
+
+        self.establish_connection(vsphere)
+
+        results = {}
+        for name in object_names:
+            try:
+                # consult vSphere for the managed_entity object that is the specified name and type
+                managed_entity = inventory.get_managed_entity(self.si_content, vimtype, name=name)
+
+                # extract moid from vim.ManagedEntity object
+                results[name] = str(managed_entity).split(':')[-1].replace("'", "")
+            except Exception as e:
+                self.logger.warning(str(e))
+
+        return (True, results)

--- a/actions/get_moid.yaml
+++ b/actions/get_moid.yaml
@@ -1,0 +1,21 @@
+---
+name: get_moid
+runner_type: run-python
+description: Returns the MOID of vSphere managed entity corresponding to the specified parameters
+enabled: true
+entry_point: get_moid.py
+parameters:
+    object_names:
+        type: array
+        description: Object names to convert to MOID
+        required: true
+    object_type:
+        type: string
+        description: The type of object name (VirtualMachine|Network|Datastore|Datacenter|Host)
+        required: true
+    vsphere:
+        type: string
+        description: Pre-Configured vsphere connection details
+        required: false
+        position: 1
+        default: ~

--- a/actions/get_moid.yaml
+++ b/actions/get_moid.yaml
@@ -11,8 +11,14 @@ parameters:
         required: true
     object_type:
         type: string
-        description: The type of object name (VirtualMachine|Network|Datastore|Datacenter|Host)
+        description: The type of object to get
         required: true
+        enum:
+          - VirtualMachine
+          - Network
+          - Datastore
+          - Datacenter
+          - Host
     vsphere:
         type: string
         description: Pre-Configured vsphere connection details

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,8 +2,9 @@
 ref: vsphere
 name: vsphere 
 description: st2 content pack containing vsphere integrations.
-version: 0.4.4
+version: 0.4.5
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:
   - Igor Cherkaev <emptywee@gmail.com>
+  - Hiroyasu OHYAMA <user.localhost2000@gmail.com>

--- a/tests/test_action_get_moid.py
+++ b/tests/test_action_get_moid.py
@@ -1,0 +1,77 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+
+from vmwarelib import inventory
+from get_moid import GetMoid
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'GetMoidTestCase'
+]
+
+
+class GetMoidTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = GetMoid
+
+    def setUp(self):
+        super(GetMoidTestCase, self).setUp()
+
+        self._action = self.get_action_instance(self.new_config)
+
+        self._action.establish_connection = mock.Mock()
+        self._action.si_content = mock.Mock()
+
+    def test_with_valid_name_and_type(self):
+        # object types thats are assumed to be specified
+        object_types = [
+            'VirtualMachine',
+            'Network',
+            'Datastore',
+            'Datacenter',
+            'Host',
+        ]
+
+        # invoke action with valid parameters
+        mock_entity = "''vim.VirtualMachine:vm-1234''"
+        with mock.patch.object(inventory,'get_managed_entity', return_value=mock_entity):
+            # test for each object types
+            for object_type in object_types:
+                result = self._action.run(object_names=['hoge'], object_type=object_type)
+
+                self.assertTrue(result[0])
+                self.assertTrue(len(result[1]) > 0)
+                self.assertEqual(result[1].get('hoge'), 'vm-1234')
+
+    def test_with_invalid_type(self):
+        # invoke action with invalid object_type which is not registered in pyVmomi
+        result = self._action.run(object_names=['hoge'], object_type='InvalidObjectType')
+
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], {})
+
+    def test_with_invalid_names(self):
+        def side_effect(*args, **kwargs):
+            # because vmwarelib.inventory.get_managed_entity raises an exeption when
+            # no matched object is found
+            raise Exception("Inventory Error: Unable to Find Object in a test")
+
+        # invoke action with invalid names which don't match any objects
+        with mock.patch.object(inventory, 'get_managed_entity', side_effect=side_effect):
+            result = self._action.run(object_names=['hoge'], object_type='VirtualMachine')
+
+        self.assertTrue(result[0])
+        self.assertEqual(result[1], {})

--- a/tests/test_action_get_moid.py
+++ b/tests/test_action_get_moid.py
@@ -47,7 +47,7 @@ class GetMoidTestCase(VsphereBaseActionTestCase):
 
         # invoke action with valid parameters
         mock_entity = "''vim.VirtualMachine:vm-1234''"
-        with mock.patch.object(inventory,'get_managed_entity', return_value=mock_entity):
+        with mock.patch.object(inventory, 'get_managed_entity', return_value=mock_entity):
             # test for each object types
             for object_type in object_types:
                 result = self._action.run(object_names=['hoge'], object_type=object_type)


### PR DESCRIPTION
This is the additional feature for #3.
This patch added action that seeks MOID of object from name and type.

Most of actions in this pack requires MOID as the parameters to identity the object of vSphere managed entity.
But, MOID is not easy to know for users because it is the internal ID of vSphere.

In contrast, object name is familiar for users because it's named by users.
And some object type (e.g. `vim.VirtualMachine`) is unique in a vCenter by the restriction of vSphere.

So I added the action to seek MOID from name and type.
In combination with this, user can utilize all existing actions through object name.

Thank you.