### PR TITLE
Adding schema file to apply the configuration schema to this pack

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,0 +1,30 @@
+---
+ssl_verify:
+  description: Using ssl/tls protocol to encrypt communications with vCenter Server.
+  type: boolean
+  default: True
+
+vsphere:
+  type: object
+  properties:
+    default:
+      type: object
+      properties:
+        host:
+          description: Hostname or IP address of accessing vSphere Server.
+          type: string
+          required: true
+        port:
+          description: TCP port number for the vSphere Server.
+          type: integer
+          required: true
+        user:
+          description: Authentication user-id for the vSphere Server.
+          type: string
+          secret: true
+          required: true
+        passwd:
+          description: The password of the specified user.
+          type: string
+          secret: true
+          required: true

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -27,3 +27,18 @@ vsphere:
           type: string
           secret: true
           required: true
+
+sensors:
+  type: object
+  properties:
+    taskinfo:
+      type: object
+      properties:
+        tasknum:
+          description: The number of tasks to check at a polling processing
+          type: integer
+          default: 1
+        vsphere:
+          description: vSphere environment which is specified in the config (set this parameter if you set to anything vSphere environemnt other than `defualt`)
+          type: string
+          default: 'default'

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -21,7 +21,6 @@ vsphere:
         user:
           description: Authentication user-id for the vSphere Server.
           type: string
-          secret: true
           required: true
         passwd:
           description: The password of the specified user.

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vsphere
 name: vsphere 
 description: st2 content pack containing vsphere integrations.
-version: 0.4.6
+version: 0.4.7
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/fixtures/cfg_new.yaml
+++ b/tests/fixtures/cfg_new.yaml
@@ -8,5 +8,5 @@
 
   sensors:
     taskinfo:
-      interval: 5
+      tasknum: 5
       vsphere: default

--- a/tests/fixtures/cfg_new_partial.yaml
+++ b/tests/fixtures/cfg_new_partial.yaml
@@ -7,5 +7,5 @@
 
   sensors:
     taskinfo:
-      interval: 5
+      tasknum: 5
       vsphere: default

--- a/tests/fixtures/config.schema.yaml
+++ b/tests/fixtures/config.schema.yaml
@@ -1,0 +1,44 @@
+---
+ssl_verify:
+  description: Using ssl/tls protocol to encrypt communications with vCenter Server.
+  type: boolean
+  default: True
+
+vsphere:
+  type: object
+  properties:
+    default:
+      type: object
+      properties:
+        host:
+          description: Hostname or IP address of accessing vSphere Server.
+          type: string
+          required: true
+        port:
+          description: TCP port number for the vSphere Server.
+          type: integer
+          required: true
+        user:
+          description: Authentication user-id for the vSphere Server.
+          type: string
+          required: true
+        passwd:
+          description: The password of the specified user.
+          type: string
+          secret: true
+          required: true
+
+sensors:
+  type: object
+  properties:
+    taskinfo:
+      type: object
+      properties:
+        tasknum:
+          description: The number of tasks to check at a polling processing
+          type: integer
+          default: 1
+        vsphere:
+          description: vSphere environment which is specified in the config (set this parameter if you set to anything vSphere environemnt other than `defualt`)
+          type: string
+          default: 'default'

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,72 @@
+import mock
+import yaml
+import json
+import re
+
+from st2client import shell
+from st2client.utils import httpclient
+from st2client.models.core import ConfigManager
+
+from st2tests.http import FakeResponse
+from st2tests.pack_resource import BasePackResourceTestCase
+
+
+class ConfigSchemaTestCase(BasePackResourceTestCase):
+    def setUp(self):
+        super(ConfigSchemaTestCase, self).setUp()
+
+        self.shell = shell.Shell()
+        self._content_schema = yaml.load(self.get_fixture_content('config.schema.yaml'))
+        self._new_config = yaml.load(self.get_fixture_content('cfg_new.yaml'))
+
+    @mock.patch.object(httpclient.HTTPClient, 'get')
+    @mock.patch.object(ConfigManager, 'update')
+    @mock.patch('st2client.commands.pack.editor')
+    @mock.patch('st2client.utils.interactive.prompt')
+    def test_set_schema(self, mock_prompt, mock_editor, mock_config_update, mock_http_get):
+        # set dummy HTTP response from the st2api
+        dummy_api_response = {
+            'id': 'dummy1234',
+            'pack': 'vsphere',
+            'attributes': self._content_schema
+        }
+        mock_http_get.return_value = FakeResponse(json.dumps(dummy_api_response), 200, 'OK')
+
+        # set dummy paramters
+        def side_effect_prompt(msg, **kwargs):
+            if re.compile(r'^ssl_verify').match(msg):
+                return 'y'
+            elif re.compile(r'^default.host').match(msg):
+                return '192.168.0.1'
+            elif re.compile(r'^default.port').match(msg):
+                return '443'
+            elif re.compile(r'^default.user').match(msg):
+                return 'Admin'
+            elif re.compile(r'^default.passwd').match(msg):
+                return 'password'
+            elif re.compile(r'^taskinfo.tasknum').match(msg):
+                return '5'
+            else:
+                return None
+        mock_prompt.side_effect = side_effect_prompt
+
+        # skip modification by editor
+        def side_effect_editor(contents):
+            return contents
+        mock_editor.edit.side_effect = side_effect_editor
+
+        # check for the result configuration is expected
+        def side_effect_config_update(config):
+            self.assertEqual(config.pack, 'vsphere')
+
+            # check for generated configuration has expected parameters
+            for k, v in self._new_config.items():
+                self.assertEqual(config.values[k], v)
+
+            return config
+        mock_config_update.side_effect = side_effect_config_update
+
+        # execute pack config command
+        ret = self.shell.run(['--debug', 'pack', 'config', 'vsphere'])
+
+        self.assertEqual(ret, 0)


### PR DESCRIPTION
Previously, there is only configuration file to configure this pack.
The configure schema file which is added in this patch has schema to set configuration equivalent to the config.yaml.

The configuration parameter of 'sensors.taskinfo.vsphere' is omitted by design because of needless to set.
This parameter indicates the vSphere environment to connect, and this is set the 'default' value by the TaskInfo sensor by default.
And vSphere environment name is statically set 'default' in this configuration schema.

It's no necessary to set this parameter by the user, so I didn't write this parameter in the schema file.

Thank you.