### PR TITLE
Config schema update for varying vsphere names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,3 +29,7 @@ Update nic actions to factor in Distributed Port Groups. When setting a network 
  
 Added global ssl_verify configuration option to disable SSL certificate verification when connecting to vSphere servers.
 Added custom JSON Encoder class to serialize VM summary (`vsphere.vm_hw_details_get`) output, hence, allowing results to be a list of dicts instead of strings. Makes it easier to access the results later in the workflows or action chains.
+
+## V0.4.8
+
+Update config.schema.yaml to support any name for vcenters

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,35 +1,36 @@
 # Change Log
 
-## V0.2
-  
-Addition of vm_hw atomic actions to create basic Virtual Machine.
+## V0.4.8
+
+Update config.schema.yaml to support any name for vcenters
+
+## V0.4.4
+
+Added global ssl_verify configuration option to disable SSL certificate verification when connecting to vSphere servers.
+Added custom JSON Encoder class to serialize VM summary (`vsphere.vm_hw_details_get`) output, hence, allowing results to be a list of dicts instead of strings. Makes it easier to access the results later in the workflows or action chains.
+
+## V0.4.3
+
+Update nic actions to factor in Distributed Port Groups. When setting a network the DPG will be used over a standard port group of the same name.
+
+## V0.4.2
+
+Updates to actions to factor in ST2 V2 changes forcing string conversions for output and publish variable syntax changes.
+vm_basic_build workflow introduction of 12 seconds delay between elements to support parrallel action load balancing
+
+## V0.4.1
+
+Improved error message around Connection/Configuration details. Addition of item get action.
+
+## V0.4
+
+Introduction of Multi Endpoint Configuration.
 
 ## V0.3
 
 Clean up of duplicate actions. Addition of moid retrieval function.
 
-## V0.4
- 
-Introduction of Multi Endpoint Configuration.
+## V0.2
+  
+Addition of vm_hw atomic actions to create basic Virtual Machine.
 
-## V0.4.1
- 
-Improved error message around Connection/Configuration details. Addition of item get action.
-
-## V0.4.2
- 
-Updates to actions to factor in ST2 V2 changes forcing string conversions for output and publish variable syntax changes.
-vm_basic_build workflow introduction of 12 seconds delay between elements to support parrallel action load balancing
-
-## V0.4.3
- 
-Update nic actions to factor in Distributed Port Groups. When setting a network the DPG will be used over a standard port group of the same name.
-
-## V0.4.4
- 
-Added global ssl_verify configuration option to disable SSL certificate verification when connecting to vSphere servers.
-Added custom JSON Encoder class to serialize VM summary (`vsphere.vm_hw_details_get`) output, hence, allowing results to be a list of dicts instead of strings. Makes it easier to access the results later in the workflows or action chains.
-
-## V0.4.8
-
-Update config.schema.yaml to support any name for vcenters

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This pack integrates with vsphere and allows for the creation and management of 
 
 ## Connection Configuration
 
-You will need to specificy the details of the vcenter instance you will be connecting to within the `config.yaml` file.
+You will need to specificy the details of the vcenter instance you will be connecting to within the `/opt/stackstorm/config/vsphere.yaml` file.
 You can specificy multiple environments using nested values
 
 ```yaml

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -5,28 +5,33 @@ ssl_verify:
   default: True
 
 vsphere:
-  type: object
+  type: "object"
+  required: true
+  patternProperties:
+      "^\\w+":
+        "$ref": "#/properties/vcenters"
+  additionalProperties: false
+
+vcenters:
+  type: "object"
   properties:
-    default:
-      type: object
-      properties:
-        host:
-          description: Hostname or IP address of accessing vSphere Server.
-          type: string
-          required: true
-        port:
-          description: TCP port number for the vSphere Server.
-          type: integer
-          required: true
-        user:
-          description: Authentication user-id for the vSphere Server.
-          type: string
-          required: true
-        passwd:
-          description: The password of the specified user.
-          type: string
-          secret: true
-          required: true
+    host:
+      description: Hostname or IP address of accessing vSphere Server.
+      type: "string"
+      required: true
+    port:
+      description: TCP port number for the vSphere Server.
+      type: "integer"
+      required: true
+    user:
+      description: Authentication user-id for the vSphere Server.
+      type: "string"
+      required: true
+    passwd:
+      description: The password of the specified user.
+      type: "string"
+      secret: true
+      required: true
 
 sensors:
   type: object

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vsphere
 name: vsphere 
 description: st2 content pack containing vsphere integrations.
-version: 0.4.7
+version: 0.4.8
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/vsphere.yaml.example
+++ b/vsphere.yaml.example
@@ -1,0 +1,8 @@
+ssl_verify: false
+vsphere:
+  vcentername:
+    host: vcenter.host
+    passwd: password
+    port: 443
+    user: username
+


### PR DESCRIPTION
Updated config.schema.yaml to enable varying vsphere names.
Allows multiple vcenters to be defined without a rigid structure within the schema file.
Build based on guidance from @Kami 
https://gist.github.com/Kami/098e9b1b364d6fb0b2aa1008135e0d18