### PR TITLE
Updated TaskInfoSensor to enable handling in uncompleted Tasks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V0.4.9
+
+Update the `TaskInfoSensor` to enable handling uncompleted Tasks.
+
 ## V0.4.8
 
 Update config.schema.yaml to support any name for vcenters

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This trigger is emitted for every task information that is invoked on the specif
 Here is a example of a trigger payload.
 ```
 {
+  state: success,
   queue_time: 2017/03/10 02:08:39,
   start_time: 2017/03/10 02:08:39,
   complete_time: 2017/03/10 02:08:40,
@@ -67,6 +68,7 @@ Each of parameters mean following.
 
 | params         | description                                                         |
 |:---------------|:--------------------------------------------------------------------|
+| state          | State of the task. The possible is same with [vim.TaskInfo.State](https://github.com/vmware/pyvmomi/blob/master/docs/vim/TaskInfo/State.rst) |
 | queue_time     | Time stamp when the task was created                                |
 | start_time     | Time stamp when the task started running                            |
 | complete_time  | Time stamp when the task was completed (whether success or failure) |

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vsphere
 name: vsphere 
 description: st2 content pack containing vsphere integrations.
-version: 0.4.8
+version: 0.4.9
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/sensors/taskinfo_sensor.py
+++ b/sensors/taskinfo_sensor.py
@@ -63,12 +63,12 @@ class TaskInfoSensor(VSphereSensor):
         self.sensor_service.dispatch(trigger='vsphere.taskinfo', payload={
             'task_id': taskinfo.key,
             'operation_name': taskinfo.descriptionId,
-            'queue_time': taskinfo.queueTime and
-                taskinfo.queueTime.strftime('%Y/%m/%d %H:%M:%S') or '',
-            'start_time': taskinfo.startTime and
-                taskinfo.startTime.strftime('%Y/%m/%d %H:%M:%S') or '',
-            'complete_time': taskinfo.completeTime and
-                taskinfo.completeTime.strftime('%Y/%m/%d %H:%M:%S') or '',
+            'queue_time':
+                taskinfo.queueTime and taskinfo.queueTime.strftime('%Y/%m/%d %H:%M:%S') or '',
+            'start_time':
+                taskinfo.startTime and taskinfo.startTime.strftime('%Y/%m/%d %H:%M:%S') or '',
+            'complete_time':
+                taskinfo.completeTime and taskinfo.completeTime.strftime('%Y/%m/%d %H:%M:%S') or '',
             'state': str(taskinfo.state),
         })
 

--- a/sensors/taskinfo_sensor.py
+++ b/sensors/taskinfo_sensor.py
@@ -1,3 +1,5 @@
+import threading
+
 from pyVmomi import vim  # pylint: disable-msg=E0611
 from base import VSphereSensor
 from datetime import datetime
@@ -26,10 +28,23 @@ class TaskInfoSensor(VSphereSensor):
 
     def poll(self):
         if self._collector:
-            for task in self._collector.ReadNextTasks(self._tasknum):
-                self._log.debug('Found a TaskInfo: %s' % task)
+            for taskinfo in self._collector.ReadNextTasks(self._tasknum):
+                self._log.debug('Found a TaskInfo: %s' % taskinfo)
 
-                self._dispatch_taskinfo(task)
+                # dispatches taskinfo trigger
+                self._dispatch_taskinfo(taskinfo)
+
+                # If task is uncompleted, waiting until it completes then dispatches it again
+                if taskinfo.state == vim.TaskInfo.State.running:
+                    threading.Thread(target=self._wait_until_task_complete,
+                                     args=[taskinfo.task]).start()
+
+    def _wait_until_task_complete(self, task):
+        """Waits until target task complete, then dispatch trigger"""
+        while task.info.state == vim.TaskInfo.State.running:
+            pass
+
+        self._dispatch_taskinfo(task.info)
 
     def _get_task_collector(self):
         # set filter to get TaskInfo which is queued in the vSphere after executing this Sensor
@@ -48,9 +63,13 @@ class TaskInfoSensor(VSphereSensor):
         self.sensor_service.dispatch(trigger='vsphere.taskinfo', payload={
             'task_id': taskinfo.key,
             'operation_name': taskinfo.descriptionId,
-            'queue_time': taskinfo.queueTime.strftime('%Y/%m/%d %H:%M:%S'),
-            'start_time': taskinfo.startTime.strftime('%Y/%m/%d %H:%M:%S'),
-            'complete_time': taskinfo.completeTime.strftime('%Y/%m/%d %H:%M:%S'),
+            'queue_time': taskinfo.queueTime and
+                taskinfo.queueTime.strftime('%Y/%m/%d %H:%M:%S') or '',
+            'start_time': taskinfo.startTime and
+                taskinfo.startTime.strftime('%Y/%m/%d %H:%M:%S') or '',
+            'complete_time': taskinfo.completeTime and
+                taskinfo.completeTime.strftime('%Y/%m/%d %H:%M:%S') or '',
+            'state': str(taskinfo.state),
         })
 
     def cleanup(self):

--- a/sensors/taskinfo_sensor.yaml
+++ b/sensors/taskinfo_sensor.yaml
@@ -11,6 +11,8 @@ trigger_types:
       properties:
         task_id:
           type: string
+        state:
+          type: string
         operation_name:
           type: string
         queue_time:

--- a/tests/test_sensor_taskinfo.py
+++ b/tests/test_sensor_taskinfo.py
@@ -65,7 +65,7 @@ class TaskInfoSensorTestCase(BaseSensorTestCase):
         # replace TaskHistoryCollector object by mock that returns dummy TaskInfo object
         sensor._collector = mock.Mock()
         sensor._collector.ReadNextTasks = mock.Mock(
-                return_value=[self.MockUncompletedTaskInfo('task-1')])
+            return_value=[self.MockUncompletedTaskInfo('task-1')])
 
         sensor.poll()
 

--- a/tests/test_sensor_taskinfo.py
+++ b/tests/test_sensor_taskinfo.py
@@ -1,11 +1,13 @@
 import mock
 import yaml
+import time
 
 from st2tests.base import BaseSensorTestCase
 from taskinfo_sensor import TaskInfoSensor
 
 from pyVim import connect
-from datetime import datetime
+from pyVmomi import vim
+from datetime import datetime, timedelta
 
 
 class TaskInfoSensorTestCase(BaseSensorTestCase):
@@ -35,6 +37,10 @@ class TaskInfoSensorTestCase(BaseSensorTestCase):
         self.assertNotEqual(contexts, [])
         self.assertEqual(len(contexts), 1)
         self.assertEqual(contexts[0]['payload']['task_id'], 'task-0')
+        self.assertNotEqual(contexts[0]['payload']['queue_time'], '')
+        self.assertNotEqual(contexts[0]['payload']['start_time'], '')
+        self.assertNotEqual(contexts[0]['payload']['complete_time'], '')
+        self.assertEqual(contexts[0]['payload']['state'], 'success')
 
     def test_no_dispatching_taskinfo(self):
         sensor = self.get_sensor_instance(config=self.cfg_new)
@@ -51,6 +57,36 @@ class TaskInfoSensorTestCase(BaseSensorTestCase):
 
         self.assertEqual(contexts, [])
 
+    def test_dispatching_uncompleted_taskinfo(self):
+        sensor = self.get_sensor_instance(config=self.cfg_new)
+
+        sensor.setup()
+
+        # replace TaskHistoryCollector object by mock that returns dummy TaskInfo object
+        sensor._collector = mock.Mock()
+        sensor._collector.ReadNextTasks = mock.Mock(
+                return_value=[self.MockUncompletedTaskInfo('task-1')])
+
+        sensor.poll()
+
+        # wait until dummy processing completes
+        time.sleep(2)
+
+        contexts = self.get_dispatched_triggers()
+
+        self.assertNotEqual(contexts, [])
+        self.assertEqual(len(contexts), 2)
+
+        self.assertEqual(contexts[0]['payload']['task_id'], 'task-1')
+        self.assertEqual(contexts[0]['payload']['state'], 'running')
+        self.assertNotEqual(contexts[0]['payload']['queue_time'], '')
+        self.assertNotEqual(contexts[0]['payload']['start_time'], '')
+        self.assertEqual(contexts[0]['payload']['complete_time'], '')
+
+        self.assertEqual(contexts[1]['payload']['task_id'], 'task-1')
+        self.assertEqual(contexts[1]['payload']['state'], 'success')
+        self.assertNotEqual(contexts[1]['payload']['complete_time'], '')
+
     class MockTaskInfo(object):
         def __init__(self, taskid='Task-1', op_name='VirtualMachine.clone'):
             self.key = taskid
@@ -58,3 +94,30 @@ class TaskInfoSensorTestCase(BaseSensorTestCase):
             self.queueTime = datetime.now()
             self.startTime = datetime.now()
             self.completeTime = datetime.now()
+            self.state = str(vim.TaskInfo.State.success)
+            self.task = mock.Mock()
+            self.task.info = self
+
+    class MockUncompletedTaskInfo(object):
+        def __init__(self, taskid='Task-1', op_name='VirtualMachine.clone'):
+            self.key = taskid
+            self.descriptionId = op_name
+            self.queueTime = datetime.now()
+            self.startTime = datetime.now()
+            self._completeTime = datetime.now() + timedelta(seconds=1)
+            self.task = mock.Mock()
+            self.task.info = self
+
+        @property
+        def completeTime(self):
+            if datetime.now() < self._completeTime:
+                return None
+            else:
+                return self._completeTime
+
+        @property
+        def state(self):
+            if datetime.now() < self._completeTime:
+                return str(vim.TaskInfo.State.running)
+            else:
+                return str(vim.TaskInfo.State.success)


### PR DESCRIPTION
This patch is the correction of #12.

These are the main points of this correction. This
- corrected a bug for converting to time as string from datetime object.
- added processing to wait uncompleted Task then dispatch the `taskinfo` Trigger after it completes.
- added `state` parameter which means Task status to the `taskinfo` Trigger.