### PR TITLE
Psm/add datacenter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V0.5.0
+
+Addition of DataCenter imput field for VM creation action and workflow. Fall back continues to function as present Although this should be provided if Multiple Datacenters are under a single Vsphere instance.
+
 ## V0.4.8
 
 Update config.schema.yaml to support any name for vcenters

--- a/actions/vm_hw_barebones_create.py
+++ b/actions/vm_hw_barebones_create.py
@@ -21,7 +21,7 @@ from vmwarelib.actions import BaseAction
 
 
 class VMCreateBareBones(BaseAction):
-    def run(self, vm_name, cluster, datastore_cluster,
+    def run(self, vm_name, cluster, datacenter, datastore_cluster,
             datastore, resourcepool, cpu_size, ram_size,
             guestos, version, description, vsphere=None):
         """
@@ -53,7 +53,11 @@ class VMCreateBareBones(BaseAction):
                                        datastore,
                                        "Datastore Cluster or Datastore")
 
-        data_center = self.si_content.rootFolder.childEntity[0]
+        
+        if datacenter:
+            data_center = inventory.get_datacenter(self.si_content, name=datacenter) 
+        else:
+            data_center = self.si_content.rootFolder.childEntity[0]
         cluster = inventory.get_cluster(self.si_content, name=cluster)
         data_store_cluster = inventory.get_datastore_cluster(
             self.si_content,

--- a/actions/vm_hw_barebones_create.yaml
+++ b/actions/vm_hw_barebones_create.yaml
@@ -20,6 +20,7 @@
       type: "string"
       description: "Datacenter name - Specify if Multiple Datacenters within your VSphere instance."
       required: false
+      default: ~
     cluster:
       type: "string"
       description: "Cluster Name to Buid VM within"

--- a/actions/vm_hw_barebones_create.yaml
+++ b/actions/vm_hw_barebones_create.yaml
@@ -16,6 +16,10 @@
       required: false
       position: 1
       default: ~
+    datacenter:
+      type: "string"
+      description: "Datacenter name - Specify if Multiple Datacenters within your VSphere instance."
+      required: false
     cluster:
       type: "string"
       description: "Cluster Name to Buid VM within"

--- a/actions/vm_hw_basic_build.yaml
+++ b/actions/vm_hw_basic_build.yaml
@@ -65,6 +65,12 @@ parameters:
     type: string
     description: Datastore core VM Files will be store against (vmx files). Use unless datastoreCluster is provided.
     position: 7
+  vm_dc: 
+    required: false
+    default: ~
+    type: string
+    description: DataCenter to Buid VM within
+    position: 2
   vm_dccluster: 
     required: true
     type: string

--- a/actions/workflows/vm_hw_basic_build.yaml
+++ b/actions/workflows/vm_hw_basic_build.yaml
@@ -12,6 +12,7 @@ vsphere.vm_hw_basic_build:
     - vm_dscluster
     - vm_datastore
     - vm_dccluster
+    - vm_dc
     - vm_guestos
     - vm_description
     - vm_ctrl_type
@@ -31,6 +32,7 @@ vsphere.vm_hw_basic_build:
         ram_size: <% $.vm_ram %>
         cpu_size: <% $.vm_cpu %>
         cluster: <% $.vm_dccluster %>
+        datacenter: <% $.vm_dc %>
         datastore_cluster: <% $.vm_dscluster %>
         datastore: <% $.vm_datastore %>
         resourcepool: <% $.vm_resourcepool %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vsphere
 name: vsphere 
 description: st2 content pack containing vsphere integrations.
-version: 0.4.8
+version: 0.5.0
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:


### PR DESCRIPTION
When VSphere has multiple DataCenters it's possible for the wrong one to be selected.
Therefore I have added the DataCenter input to the actions and basic machine workflow.
If this field is not provided that the workflow will continue to function as in previous versions (taking first defined datacenter).
Recommendation would be to start populating this field otherwise there is a risk of the DC, DC Cluster and datastores not being associated and the build failing.