### PR TITLE
Changed to be able to handle all vim Objects that pyVmomi prepared

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V0.7.2
+
+Changed to be able to handle all vim Objects that pyvmomi prepared
+
 ## V0.7.1
 
 Fixed non-unique position parameters

--- a/actions/get_moid.py
+++ b/actions/get_moid.py
@@ -32,17 +32,9 @@ class GetMoid(BaseAction):
         - dict: key value pair of object_name and moid.
         """
 
-        if object_type == 'VirtualMachine':
-            vimtype = vim.VirtualMachine
-        elif object_type == 'Network':
-            vimtype = vim.Network
-        elif object_type == 'Datastore':
-            vimtype = vim.Datastore
-        elif object_type == 'Datacenter':
-            vimtype = vim.Datacenter
-        elif object_type == 'Host':
-            vimtype = vim.HostSystem
-        else:
+        try:
+            vimtype = getattr(vim, object_type)
+        except AttributeError:
             self.logger.warning("specified object_type ('%s') is not supported" % object_type)
             return (False, {})
 

--- a/actions/get_moid.yaml
+++ b/actions/get_moid.yaml
@@ -14,11 +14,46 @@ parameters:
         description: The type of object to get
         required: true
         enum:
-          - VirtualMachine
-          - Network
-          - Datastore
+          - AuthorizationManager
+          - ClusterComputeResource
+          - ComputeResource
+          - CustomFieldsManager
           - Datacenter
-          - Host
+          - Datastore
+          - DiagnosticManager
+          - DistributedVirtualSwitch
+          - DrsStatsManager/InjectorWorkload
+          - Extension
+          - ExtensionManager
+          - HbrManager
+          - HostSystem
+          - HttpNfcLease
+          - IpPoolManager
+          - LatencySensitivity
+          - LicenseAssignmentManager
+          - LicenseManager
+          - LocalizationManager
+          - ManagedEntity
+          - Network
+          - OpaqueNetwork
+          - OvfConsumer
+          - OvfManager
+          - PerformanceManager
+          - ResourcePlanningManager
+          - ResourcePool
+          - ServiceInstance
+          - ServiceManager
+          - SessionManager
+          - SharesInfo
+          - SimpleCommand
+          - StoragePod
+          - StorageResourceManager
+          - TaskFilterSpec
+          - TaskInfo
+          - UpdateVirtualMachineFilesResult
+          - VirtualApp
+          - VirtualDiskManager
+          - VirtualMachine
     vsphere:
         type: string
         description: Pre-Configured vsphere connection details

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vsphere
 name: vsphere 
 description: st2 content pack containing vsphere integrations.
-version: 0.7.1
+version: 0.7.2
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/test_action_get_moid.py
+++ b/tests/test_action_get_moid.py
@@ -42,7 +42,7 @@ class GetMoidTestCase(VsphereBaseActionTestCase):
             'Network',
             'Datastore',
             'Datacenter',
-            'Host',
+            'HostSystem',
         ]
 
         # invoke action with valid parameters


### PR DESCRIPTION
In the previous implementation on the `get_moid` action, we could specify only few type of objects to get MOID.
But many type of objects are prepared in the [pyVmomi](https://github.com/vmware/pyvmomi/) that this pack depends on.

By this change, user can get MOID(s) of all type's object(s) that pyVmomi prepared.

Thank you.