### PR TITLE
Fixed the problem to looking over the task state checking in the action library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V0.7.3
+
+Fixed the problem to looking over the task state checking in the action library
+
 ## V0.7.2
 
 Changed to be able to handle all vim Objects that pyvmomi prepared

--- a/actions/vm_create_from_template.py
+++ b/actions/vm_create_from_template.py
@@ -23,6 +23,7 @@ class VMCreateFromTemplate(BaseAction):
 
     def run(self, name, template_id, datacenter_id, resourcepool_id,
             datastore_id, vsphere=None):
+        is_success = True
         self.establish_connection(vsphere)
 
         # convert ids to stubs
@@ -49,6 +50,7 @@ class VMCreateFromTemplate(BaseAction):
                                      spec=clonespec)
         self._wait_for_task(task)
         if task.info.state != vim.TaskInfo.State.success:
-            raise Exception(task.info.error.msg)
+            is_success = False
+            self.logger.warning(task.info.error.msg)
 
-        return {'task_id': task._moId, 'vm_id': task.info.result._moId}
+        return (is_success, {'task_id': task._moId, 'vm_id': task.info.result._moId})

--- a/actions/vmwarelib/actions.py
+++ b/actions/vmwarelib/actions.py
@@ -80,6 +80,7 @@ class BaseAction(Action):
         return si
 
     def _wait_for_task(self, task):
-        while task.info.state == vim.TaskInfo.State.running:
+        while (task.info.state == vim.TaskInfo.State.queued or
+               task.info.state == vim.TaskInfo.State.running):
             eventlet.sleep(1)
         return task.info.state == vim.TaskInfo.State.success

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vsphere
 name: vsphere 
 description: st2 content pack containing vsphere integrations.
-version: 0.7.2
+version: 0.7.3
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/test_action_create_from_template.py
+++ b/tests/test_action_create_from_template.py
@@ -1,0 +1,128 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import eventlet
+import mock
+import threading
+import vm_create_from_template
+
+from datetime import datetime
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from pyVmomi import vim  # pylint: disable-msg=E0611
+
+__all__ = [
+    'CreateFromTemplateTestCase'
+]
+
+
+class CreateFromTemplateTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = vm_create_from_template.VMCreateFromTemplate
+
+    def setUp(self):
+        super(CreateFromTemplateTestCase, self).setUp()
+
+        self._action = self.get_action_instance(self.new_config)
+
+        self._action.establish_connection = mock.Mock()
+        self._action.si_content = mock.Mock()
+
+    @mock.patch.object(vm_create_from_template, 'vim')
+    @mock.patch.object(vm_create_from_template, 'inventory')
+    def test_action_with_queued_state(self, mock_inventory, mock_vim):
+        # To check task state, set to return TaskInfo.State value
+        mock_vim.TaskInfo.State = vim.TaskInfo.State
+
+        mock_task = mock.Mock()
+        mock_task.info.state = vim.TaskInfo.State.queued
+        mock_template = mock.Mock()
+        mock_template.CloneVM_Task.return_value = mock_task
+        mock_inventory.get_virtualmachine.return_value = mock_template
+
+        params = {
+            'name': 'creating_vm',
+            'template_id': 'vm-1',
+            'datacenter_id': 'datacenter-1',
+            'resourcepool_id': 'resourcepool-1',
+            'datastore_id': 'datastore-1',
+        }
+
+        # creating and starting mock task
+        mock_task_thread = MockTaskThread(mock_task)
+        mock_task_thread.start()
+
+        result = self._action.run(**params)
+
+        self.assertTrue(result[0])
+
+        # stopping mock task
+        mock_task_thread.stop()
+
+    @mock.patch.object(vm_create_from_template, 'vim')
+    @mock.patch.object(vm_create_from_template, 'inventory')
+    def test_action_with_queued_state_and_failed(self, mock_inventory, mock_vim):
+        # To check task state, set to return TaskInfo.State value
+        mock_vim.TaskInfo.State = vim.TaskInfo.State
+
+        mock_task = mock.Mock()
+        mock_task.info.state = vim.TaskInfo.State.queued
+        mock_template = mock.Mock()
+        mock_template.CloneVM_Task.return_value = mock_task
+        mock_inventory.get_virtualmachine.return_value = mock_template
+
+        params = {
+            'name': 'creating_vm',
+            'template_id': 'vm-1',
+            'datacenter_id': 'datacenter-1',
+            'resourcepool_id': 'resourcepool-1',
+            'datastore_id': 'datastore-1',
+        }
+
+        # creating and starting mock task which will fail finally
+        mock_task_thread = MockTaskThread(mock_task, will_fail=True)
+        mock_task_thread.start()
+
+        result = self._action.run(**params)
+
+        self.assertFalse(result[0])
+
+        # stopping mock task
+        mock_task_thread.stop()
+
+
+# This is the class to emulate the Task to change the state every second.
+class MockTaskThread(threading.Thread):
+    def __init__(self, mock_task, will_fail=False):
+        super(MockTaskThread, self).__init__()
+
+        self.mock_task = mock_task
+        self.is_stopped = False
+        self.woken_time = datetime.now()
+        self.final_state = vim.TaskInfo.State.success
+        if will_fail:
+            self.final_state = vim.TaskInfo.State.error
+
+    def run(self):
+        while not self.is_stopped:
+            passed_seconds = (datetime.now() - self.woken_time).seconds
+            if passed_seconds > 2:
+                self.mock_task.info.state = self.final_state
+            elif passed_seconds > 1:
+                self.mock_task.info.state = vim.TaskInfo.State.running
+
+            eventlet.sleep()
+
+    def stop(self):
+        self.is_stopped = True
+        self.join(1)


### PR DESCRIPTION
## Abstract
Some task would be failed because of the looking over the task status checking.

## Background / Problem
The execution task on the vSphere can take the status of [`queued`](https://github.com/vmware/pyvmomi/blob/575ab56eb56f32f53c98f40b9b496c6219c161da/docs/vim/TaskInfo/State.rst) before `running`.
If the state of a task is `queued`, the [`_wait_for_task` function](https://github.com/StackStorm-Exchange/stackstorm-vsphere/blob/master/actions/vmwarelib/actions.py#L83) won't wait. This problem may make some action fail like [this](https://gist.github.com/userlocalhost/9767f7fb679d9745edd0e96ec8f726f3).

## Solution
In this patch, I changed as follows.
- adding the 'queued' task state checking to the `_wait_for_task` method for preventing looking over the task status checking. 
- correcting the format of return value which conformed to the manner of StackStorm action-script in the action `vm_create_from_template`.
