### PR TITLE
Enabled to set IP Addresses for each NetworkAdapters in the 'vm_create_from_template' action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V0.7.4
+
+Enabled to specify IP Address for each NetworkAdapters in the 'vm_create_from_template' action
+
 ## V0.7.3
 
 Fixed the problem to looking over the task state checking in the action library

--- a/actions/vm_create_from_template.py
+++ b/actions/vm_create_from_template.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import socket
 from pyVmomi import vim  # pylint: disable-msg=E0611
 
 from vmwarelib import inventory
@@ -20,9 +21,10 @@ from vmwarelib.actions import BaseAction
 
 
 class VMCreateFromTemplate(BaseAction):
+    NETWORK_PARAMS = [u'ipaddr', u'netmask', u'gateway', u'domain']
 
     def run(self, name, template_id, datacenter_id, resourcepool_id,
-            datastore_id, vsphere=None):
+            datastore_id, vsphere=None, networks=[]):
         is_success = True
         self.establish_connection(vsphere)
 
@@ -40,11 +42,46 @@ class VMCreateFromTemplate(BaseAction):
         relocatespec.datastore = datastore
         relocatespec.pool = resourcepool
 
+        # When the customize parameters for the network-adapters are specified,
+        # this makes a configration to customize a deploying virtual machine.
+        # (By default, this customizes nothing)
+        custom_adapters = []
+        for network in networks:
+            # The validator for the 'networks' parameter is needed because of
+            # the restriction[*1] that there is no validation processing for the
+            # array type value in the action parameter yet.
+            #
+            # [*1] https://github.com/StackStorm/st2/issues/3160
+            if not self._validate_networks_param(network):
+                break
+
+            # set customize configuration to set IP address to the network adapters.
+            adaptermap = vim.vm.customization.AdapterMapping()
+            adaptermap.adapter = vim.vm.customization.IPSettings()
+            adaptermap.adapter.ip = vim.vm.customization.FixedIp()
+            adaptermap.adapter.ip.ipAddress = network.get('ipaddr', '0.0.0.0')
+            adaptermap.adapter.subnetMask = network.get('netmask', '255.255.255.0')
+            adaptermap.adapter.gateway = network.get('gateway', '0.0.0.0')
+
+            custom_adapters.append(adaptermap)
+
         # clone spec
         clonespec = vim.vm.CloneSpec()
         clonespec.location = relocatespec
         clonespec.powerOn = False
         clonespec.template = False
+
+        # customize networ adapter only when the networks parameter is specified
+        if custom_adapters:
+            customspec = vim.vm.customization.Specification()
+
+            customspec.identity = vim.vm.customization.LinuxPrep(
+                domain=network.get('domain', 'localhost'),
+                hostName=vim.vm.customization.FixedName(name=name))
+            customspec.nicSettingMap = custom_adapters
+            customspec.globalIPSettings = vim.vm.customization.GlobalIPSettings()
+
+            clonespec.customization = customspec
 
         task = template.CloneVM_Task(folder=target_folder, name=name,
                                      spec=clonespec)
@@ -54,3 +91,23 @@ class VMCreateFromTemplate(BaseAction):
             self.logger.warning(task.info.error.msg)
 
         return (is_success, {'task_id': task._moId, 'vm_id': task.info.result._moId})
+
+    def _validate_networks_param(self, param):
+        # Checks parameter value type
+        if not isinstance(param, dict):
+            self.logger.warning("Invalid 'networks' parameter(%s) is specified" % str(param))
+            return False
+
+        # Checks unnecessary parameters are specified
+        if not all([x in self.NETWORK_PARAMS for x in param.keys()]):
+            self.logger.warning("The unnecessary keys are specified")
+            return False
+
+        # Checks all IP Address informations are corrected
+        try:
+            [socket.inet_aton(param[x]) for x in [u'ipaddr', u'netmask', u'gateway'] if x in param]
+        except socket.error:
+            self.logger.warning("Invalid IP Address is specified in the 'networks'")
+            return False
+
+        return True

--- a/actions/vm_create_from_template.yaml
+++ b/actions/vm_create_from_template.yaml
@@ -30,4 +30,25 @@
       type: "string"
       description: "Datastore in which to place VM."
       required: true
-
+    networks:
+      type: "array"
+      description: "(Optional) Configuration to set IP addresses for each Network-adapters"
+      additionalProperties: false
+      properties:
+        ipaddr:
+          type: "string"
+          description: "IP Address to set to the Network Adapter"
+          default: '0.0.0.0'
+        netmask:
+          type: "string"
+          description: "Subnetmask of the specified IP Address"
+          default: '255.255.255.0'
+        gateway:
+          type: "string"
+          description: "Gateway address associated with the specified IP Address"
+          default: '0.0.0.0'
+        domain:
+          type: "string"
+          description: "Domain name which is set to the target Network Adapter"
+          default: 'localhost'
+      default: []

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vsphere
 name: vsphere 
 description: st2 content pack containing vsphere integrations.
-version: 0.7.3
+version: 0.7.4
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:


### PR DESCRIPTION
## Abstract
This patch enables to specify IP Addresses for each NetworkAdapters from the parameter of 'vm_create_from_template' action (for #24).

## Execution Result
This is a result of the st2 command
```
$ st2 run vsphere.vm_create_from_template \
> resourcepool_id='resgroup-8' \
> datacenter_id='datacenter-2' \
> datastore_id='datastore-12' \
> template_id='vm-442' \
> name='ohyama-test-0807-03' \
> networks=['{"ipaddr": "192.168.88.19", "gateway":"192.168.88.1"}','{"ipaddr": "192.168.100.21", "netmask": "255.255.0.0"}']
..
id: 598839e0f7764860dc8a108a
status: succeeded
parameters: 
  datacenter_id: datacenter-2
  datastore_id: datastore-12
  name: ohyama-test-0807-03
  networks:
  - gateway: 192.168.88.1
    ipaddr: 192.168.88.19
  - ipaddr: 192.168.100.21
    netmask: 255.255.0.0
  resourcepool_id: resgroup-8
  template_id: vm-442
result: 
  exit_code: 0
  result:
    task_id: task-10508
    vm_id: vm-894
  stderr: ''
  stdout: ''
```

And here is the network informations of the cloned VM after booting it.
```
ohyama@ohyama-test-0807-03:~$ ifconfig 
ens160    Link encap:Ethernet  HWaddr 00:50:56:8a:f2:0c  
          inet addr:192.168.88.19  Bcast:192.168.88.255  Mask:255.255.255.0
          inet6 addr: fe80::250:56ff:fe8a:f20c/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:390 errors:0 dropped:0 overruns:0 frame:0
          TX packets:40 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:28370 (28.3 KB)  TX bytes:6471 (6.4 KB)

ens192    Link encap:Ethernet  HWaddr 00:50:56:8a:b8:82  
          inet addr:192.168.100.21  Bcast:192.168.255.255  Mask:255.255.0.0
          inet6 addr: fe80::250:56ff:fe8a:b882/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:2 errors:0 dropped:0 overruns:0 frame:0
          TX packets:8 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:120 (120.0 B)  TX bytes:648 (648.0 B)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:6096 errors:0 dropped:0 overruns:0 frame:0
          TX packets:6096 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1 
          RX bytes:451216 (451.2 KB)  TX bytes:451216 (451.2 KB)

ohyama@ohyama-test-0807-03:~$ route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         192.168.88.1    0.0.0.0         UG    0      0        0 ens160
192.168.0.0     0.0.0.0         255.255.0.0     U     0      0        0 ens192
192.168.88.0    0.0.0.0         255.255.255.0   U     0      0        0 ens160
ohyama@ohyama-test-0807-03:~$ 
```
