### PR TITLE
updated example connection port type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ssl_verify: true
 vsphere:
   default:
     host: "myvsphere.local"
-    port: "443"
+    port: 443
     user: "st2"
     passwd: "ItsASecret"
 ```


### PR DESCRIPTION
Just a small update, I am new to ST2 and though this may be helpful to other new comers as well. 

The current example results in an error since the port type should be an integer. 

```yaml
---
ssl_verify: true
vsphere:
  default:
    host: "myvsphere.local"
    port: "443"
    user: "st2"
    passwd: "ItsASecret"
```


The example uses a string and this results in an error.

```python-traceback
root@f091efb89fe9:/# st2ctl reload --register-configs
Registering content...[flags = --config-file /etc/st2/st2.conf --register-configs]
2018-03-27 23:32:03,782 INFO [-] Connecting to database "st2" @ "mongo:27017" as user "None".
2018-03-27 23:32:04,148 INFO [-] =========================================================
2018-03-27 23:32:04,148 INFO [-] ############## Registering configs ######################
2018-03-27 23:32:04,148 INFO [-] =========================================================
2018-03-27 23:32:04,309 WARNING [-] Failed to register configs: Failed to register config "/opt/stackstorm/configs/vsphere.yaml" for pack "vsphere": Failed validating attribute "vsphere.default.port" in config for pack "vsphere" (/opt/stackstorm/configs/vsphere.yaml): '443' is not of type u'integer'

Failed validating u'type' in schema['properties'][u'vsphere'][u'patternProperties'][u'^\\w+'][u'properties'][u'port']:
    {u'description': u'TCP port number for the vSphere Server.',
     u'required': True,
     u'type': u'integer'}

On instance[u'vsphere']['default'][u'port']:
    '443'
Traceback (most recent call last):
  File "/usr/bin/st2-register-content", line 22, in <module>
    sys.exit(content_loader.main(sys.argv[1:]))
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/content/bootstrap.py", line 388, in main
    register_content()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/content/bootstrap.py", line 371, in register_content
    register_configs()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/content/bootstrap.py", line 326, in register_configs
    raise e
ValueError: Failed to register config "/opt/stackstorm/configs/vsphere.yaml" for pack "vsphere": Failed validating attribute "vsphere.default.port" in config for pack "vsphere" (/opt/stackstorm/configs/vsphere.yaml): '443' is not of type u'integer'

Failed validating u'type' in schema['properties'][u'vsphere'][u'patternProperties'][u'^\\w+'][u'properties'][u'port']:
    {u'description': u'TCP port number for the vSphere Server.',
     u'required': True,
     u'type': u'integer'}

On instance[u'vsphere']['default'][u'port']:
    '443'
##### st2 components status #####
st2actionrunner PID: 90
st2api PID: 55
st2api PID: 213
st2stream PID: 57
st2stream PID: 212
st2auth PID: 44
st2auth PID: 214
st2garbagecollector PID: 40
st2notifier PID: 50
st2resultstracker PID: 48
st2rulesengine PID: 53
st2sensorcontainer PID: 39
st2chatops is not running.
mistral-server PID: 364
mistral.api PID: 361
mistral.api PID: 393
mistral.api PID: 394
```