### PR TITLE
Add some actions enabling Guest Operations APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,65 @@ This is what each parameter means:
 | `operation_name` | The name of the operation that created the task                     |
 | `task_id`        | The MOID (Managed Object Reference ID) that identifies target task  |
 
+## Guest Operations
+
+The Guest Operations API allows for direct file and process manipulation inside a virtual machine.
+Consider the use case where you want to run a PowerShell script inside a virtual machine.  Here are the steps you would take:
+
+1. Create a PowerShell script in your own pack (for example "mypack/scripts/Return.ps1" - see below)
+2. Execute the vsphere.guest_script_run workflow.
+3. Examine the result - if the script returns a non-zero exit code, the workflow will fail.  Orquesta [does not allow for output when a workflow fails](https://github.com/StackStorm/st2/issues/4336), so obtaining the exit code, stdout, and stderr from the process requires peeking at the subtasks.
+
+This currently requires a username and password known to the guest to be given as parameters.  It does not yet support vSphere SSO.
+
+The simplest example of this facility is to write a script that exits with the argument given.  Create a script called "Return.ps1" in a pack directory:
+```
+param (
+    [Parameter(Mandatory=$true)][int]$retval
+)
+echo "This is stdout, going to exit with $retval"
+Write-Error "This is stderr, going to exit with $retval"
+exit $retval
+```
+
+Now execute this script inside the guest using the following command:
+
+    # st2 run vsphere.guest_script_run vm_id=MOID username=USERNAME password=PASSWORD interpreter="C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\PowerShell.EXE" interpreter_arguments="-NonInteractive" script="pack:mypack/scripts/Return.ps1" script_arguments=0
+
+This in turn executes a Orquesta workflow that automates all the steps required:
+```
+status: succeeded
+start_timestamp: Tue, 02 Oct 2018 15:10:08 UTC
+end_timestamp: Tue, 02 Oct 2018 15:10:26 UTC
+result:
+  output:
+    exit_code: 0
+    stderr: "C:\Users\Administrator\AppData\Local\Temp\stackstorm_vmware246_scriptrunner\Return.ps1 : This is
+stderr, going to exit with 0
+At line:1 char:1
++ C:\Users\ADMINI~1\AppData\Local\Temp\stackstorm_vmware246_scriptrunne ...
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
+    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Return.ps1
+
+"
+    stdout: "This is stdout, going to exit with 0
+"
++--------------------------+------------------------+---------------+-----------------------------+-------------------------------+
+| id                       | status                 | task          | action                      | start_timestamp               |
++--------------------------+------------------------+---------------+-----------------------------+-------------------------------+
+| 5bb38a5156d2c100359a856d | succeeded (2s elapsed) | dir_create    | vsphere.guest_dir_create    | Tue, 02 Oct 2018 15:10:09 UTC |
+| 5bb38a5356d2c100359a8570 | succeeded (2s elapsed) | file_upload   | vsphere.guest_file_upload   | Tue, 02 Oct 2018 15:10:11 UTC |
+| 5bb38a5656d2c100359a8573 | succeeded (1s elapsed) | process_start | vsphere.guest_process_start | Tue, 02 Oct 2018 15:10:14 UTC |
+| 5bb38a5856d2c100359a8576 | succeeded (1s elapsed) | process_wait  | vsphere.guest_process_wait  | Tue, 02 Oct 2018 15:10:16 UTC |
+| 5bb38a5a56d2c100359a8579 | succeeded (2s elapsed) | get_stdout    | vsphere.guest_file_read     | Tue, 02 Oct 2018 15:10:18 UTC |
+| 5bb38a5d56d2c100359a857c | succeeded (1s elapsed) | get_stderr    | vsphere.guest_file_read     | Tue, 02 Oct 2018 15:10:21 UTC |
+| 5bb38a5f56d2c100359a857f | succeeded (2s elapsed) | dir_delete__3 | vsphere.guest_dir_delete    | Tue, 02 Oct 2018 15:10:23 UTC |
++--------------------------+------------------------+---------------+-----------------------------+-------------------------------+
+```
+
+Changing the script_arguments to another number results in the action failing.
+
 ## Todo
 
 * Create actions for vsphere environment data retrieval. Allow for integration with external systems for accurate action calls with informed parameter values.
@@ -150,6 +209,15 @@ PYVMOMI 6.0 requires alternative connection coding and Python 2.7.9 minimum due 
 * `vsphere.get_moid` - Returns the MOID of vSphere managed entity corresponding to the specified parameters
 * `vsphere.get_vmconsole_urls` - Retrieves urls of the virtual machines' consoles
 * `vsphere.get_vms` - Retrieves the virtual machines on a vCenter Server system. It computes the union of Virtual Machine sets based on each parameter.
+* `vsphere.guest_dir_create` - Create a directory inside the guest.
+* `vsphere.guest_dir_delete` - Delete a directory inside the guest.
+* `vsphere.guest_file_create` - Create a file inside the guest.
+* `vsphere.guest_file_delete` - Delete a file inside the guest.
+* `vsphere.guest_file_read` - Read the contents of a file inside the guest.
+* `vsphere.guest_file_upload` - Upload the contents of a file to the guest.
+* `vsphere.guest_process_start` - Start a process inside the guest.
+* `vsphere.guest_process_wait` - Wait for a process to finish inside the guest.
+* `vsphere.guest_script_run` - Orquesta workflow to upload and run a script inside the guest, and capture results.
 * `vsphere.hello_vsphere` - Wait for a Task to complete and returns its result.
 * `vsphere.host_get` - Retrieves the Summary information for an ESX host.
 * `vsphere.host_network_hints_get` - Retrieves the Network Hints for an ESX host.

--- a/actions/guest_dir_create.py
+++ b/actions/guest_dir_create.py
@@ -1,0 +1,43 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.guest import GuestAction
+
+
+class CreateTemporaryDirectoryInGuest(GuestAction):
+
+    def run(self, vm_id, username, password, prefix, suffix, vsphere=None):
+        """
+        Create a temporary directory inside a guest.
+
+        Args:
+        - vm_id: MOID of the Virtual Machine
+        - username: username to perform the operation
+        - password: password of that user
+        - prefix: Directory name prefix, recommend trailing with underscore
+        - suffix: Directory name suffix; recommend leading with underscore
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+
+        Returns:
+        - the new directory name (a full path known to the guest)
+
+        Throws:
+        - Exception when something goes wrong
+          TODO: this should be improved
+        """
+
+        self.prepare_guest_operation(vsphere, vm_id, username, password)
+        return self.guest_file_manager.CreateTemporaryDirectoryInGuest(
+            self.vm, self.guest_credentials, prefix, suffix)

--- a/actions/guest_dir_create.yaml
+++ b/actions/guest_dir_create.yaml
@@ -1,0 +1,40 @@
+---
+  name: guest_dir_create
+  runner_type: python-script
+  description: "Creates a temporary directory inside the guest."
+  enabled: true
+  entry_point: guest_dir_create.py
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to modify."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    prefix:
+      type: string
+      description: "Prefix for the directory name."
+      required: true
+      position: 3
+    suffix:
+      type: string
+      description: "Suffix for the directory name."
+      required: true
+      position: 4
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 5
+      default: ~
+

--- a/actions/guest_dir_delete.py
+++ b/actions/guest_dir_delete.py
@@ -1,0 +1,36 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.guest import GuestAction
+
+
+class DeleteDirectoryInGuest(GuestAction):
+
+    def run(self, vm_id, username, password, guest_directory, recursive,
+            vsphere=None):
+        """
+        Delete a directory inside a guest.
+
+        Args:
+        - vm_id: MOID of the Virtual Machine
+        - username: username to perform the operation
+        - password: password of that user
+        - guest_directory: Directory name inside the guest
+        - recursive: whether the operation is recursive
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+        """
+        self.prepare_guest_operation(vsphere, vm_id, username, password)
+        self.guest_file_manager.DeleteDirectoryInGuest(
+            self.vm, self.guest_credentials, guest_directory, recursive)

--- a/actions/guest_dir_delete.yaml
+++ b/actions/guest_dir_delete.yaml
@@ -1,0 +1,41 @@
+---
+  name: guest_dir_delete
+  runner_type: python-script
+  description: "Deletes a directory inside the guest."
+  enabled: true
+  entry_point: guest_dir_delete.py
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to modify."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    guest_directory:
+      type: string
+      description: "Directory name inside the guest."
+      required: true
+      position: 3
+    recursive:
+      type: boolean
+      description: "If true, deletion is recursive."
+      required: false
+      default: false
+      position: 4
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 5
+      default: ~
+

--- a/actions/guest_file_create.py
+++ b/actions/guest_file_create.py
@@ -1,0 +1,40 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.guest import GuestAction
+
+
+class CreateTemporaryFileInGuest(GuestAction):
+
+    def run(self, vm_id, username, password, guest_directory,
+            prefix, suffix, vsphere=None):
+        """
+        Create a temporary file inside a guest.
+
+        Args:
+        - vm_id: MOID of the Virtual Machine
+        - username: username to perform the operation
+        - password: password of that user
+        - guest_directory: the directory in the guest to store the file
+        - prefix: file name prefix, recommend trailing with underscore
+        - suffix: file name suffix; recommend leading with underscore
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+
+        Returns:
+        - the full path to the file in the guest
+        """
+        self.prepare_guest_operation(vsphere, vm_id, username, password)
+        return self.guest_file_manager.CreateTemporaryFileInGuest(
+            self.vm, self.guest_credentials, prefix, suffix, guest_directory)

--- a/actions/guest_file_create.yaml
+++ b/actions/guest_file_create.yaml
@@ -1,0 +1,45 @@
+---
+  name: guest_file_create
+  runner_type: python-script
+  description: "Creates a temporary file inside the guest."
+  enabled: true
+  entry_point: guest_file_create.py
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to modify."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    guest_directory:
+      type: string
+      description: "Directory in the guest where the file should go."
+      required: true
+      position: 3
+    prefix:
+      type: string
+      description: "Prefix for the file name."
+      required: true
+      position: 4
+    suffix:
+      type: string
+      description: "Suffix for the file name."
+      required: true
+      position: 5
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 6
+      default: ~
+

--- a/actions/guest_file_delete.py
+++ b/actions/guest_file_delete.py
@@ -1,0 +1,41 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.guest import GuestAction
+
+
+class DeleteFileInGuest(GuestAction):
+
+    def run(self, vm_id, username, password, guest_directory, guest_file,
+            vsphere=None):
+        """
+        Delete a file inside a guest.
+
+        Args:
+        - vm_id: MOID of the Virtual Machine
+        - username: username to perform the operation
+        - password: password of that user
+        - guest_directory: [optional] Directory in guest containing the file.
+        - guest_file: Full path to file in guest to delete if guest_directory
+        -             is not specified, otherwise this is relative.
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+        """
+        self.prepare_guest_operation(vsphere, vm_id, username, password)
+        if not guest_directory:
+            full_path = guest_file
+        else:
+            full_path = self.joinpath(guest_directory, guest_file)
+        self.guest_file_manager.DeleteFileInGuest(
+            self.vm, self.guest_credentials, full_path)

--- a/actions/guest_file_delete.yaml
+++ b/actions/guest_file_delete.yaml
@@ -1,0 +1,40 @@
+---
+  name: guest_file_delete
+  runner_type: python-script
+  description: "Deletes a file inside the guest."
+  enabled: true
+  entry_point: guest_file_delete.py
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to modify."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    guest_directory:
+      type: string
+      description: "Full path in the guest to the directory holding the file.  If defined, guest_file is relative."
+      required: false
+      position: 3
+    guest_file:
+      type: string
+      description: "Full or relative (to guest_directory) path in the guest to the file to delete."
+      required: true
+      position: 4
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 5
+      default: ~
+

--- a/actions/guest_file_read.py
+++ b/actions/guest_file_read.py
@@ -1,0 +1,45 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.guest import GuestAction
+import requests
+
+
+class InitiateFileTransferFromGuest(GuestAction):
+
+    def run(self, vm_id, username, password, guest_directory, guest_file,
+            vsphere=None):
+        """
+        Read the contents of a file on the guest.
+
+        Args:
+        - vm_id: MOID of the Virtual Machine
+        - username: username to perform the operation
+        - password: password of that user
+        - guest_directory: full path to the directory containing the file
+        - guest_file: full path to the file on the guest if guest_directory
+        -             is None, otherwise a path relative to guest_directory
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+        """
+        self.prepare_guest_operation(vsphere, vm_id, username, password)
+        if not guest_directory:
+            full_path = guest_file
+        else:
+            full_path = self.joinpath(guest_directory, guest_file)
+        dl_url = self.guest_file_manager.InitiateFileTransferFromGuest(
+            self.vm, self.guest_credentials, guestFilePath=full_path)
+        response = requests.get(dl_url.url, verify=False)
+        response.raise_for_status()  # raise if status_code not 200
+        return response.text

--- a/actions/guest_file_read.yaml
+++ b/actions/guest_file_read.yaml
@@ -1,0 +1,40 @@
+---
+  name: guest_file_read
+  runner_type: python-script
+  description: "Read a file inside the guest."
+  enabled: true
+  entry_point: guest_file_read.py
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to modify."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    guest_directory:
+      type: string
+      description: "Full path in the guest to the directory holding the file.  If defined, guest_file is relative."
+      required: false
+      position: 3
+    guest_file:
+      type: string
+      description: "Full or relative (to guest_directory) path in the guest to the file."
+      required: true
+      position: 4
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 5
+      default: ~
+

--- a/actions/guest_file_upload.py
+++ b/actions/guest_file_upload.py
@@ -1,0 +1,67 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.guest import GuestAction
+from pyVmomi import vim  # pylint: disable-msg=E0611
+import os
+import requests
+
+
+class InitiateFileTransferToGuest(GuestAction):
+
+    def run(self, vm_id, username, password, guest_directory, local_path,
+            vsphere=None):
+        """
+        Upload a file to a directory inside a guest.
+
+        Args:
+        - vm_id: MOID of the Virtual Machine
+        - username: username to perform the operation
+        - password: password of that user
+        - guest_directory: Directory name in the guest to store the file
+        - local_path: The full path to the local file, or a path
+        -             relative to the packs directory when prefixed
+        -             with pack:
+        -             If this pack is a development pack (inside packs.dev)
+        -             then the "pack:" prefix indicates packs.dev as the
+        -             relative starting point.
+        -             examples: /opt/stackstorm/packs/mypack/path/to/file
+        -                       pack:mypack/path-inside-pack/to/file
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+        """
+        self.prepare_guest_operation(vsphere, vm_id, username, password)
+
+        if (local_path.startswith("pack:")):
+            packsdir =\
+                os.path.dirname(
+                    os.path.dirname(
+                        os.path.dirname(os.path.abspath(__file__))))
+            full_local_path = os.path.join(packsdir, local_path[5:])
+        else:
+            full_local_path = local_path
+
+        with open(full_local_path, 'rb') as myfile:
+            file_contents = myfile.read()
+        guest_filename = os.path.basename(full_local_path)
+
+        file_attribute = vim.vm.guest.FileManager.FileAttributes()
+        full_path = self.joinpath(guest_directory, guest_filename)
+        url = self.guest_file_manager.InitiateFileTransferToGuest(
+            self.vm, self.guest_credentials, full_path, file_attribute,
+            len(file_contents), True)
+
+        response = requests.put(url, data=file_contents, verify=False)
+        response.raise_for_status()  # raise if status_code is not 200
+        return full_path

--- a/actions/guest_file_upload.yaml
+++ b/actions/guest_file_upload.yaml
@@ -1,0 +1,40 @@
+---
+  name: guest_file_upload
+  runner_type: python-script
+  description: "Upload a file to the guest."
+  enabled: true
+  entry_point: guest_file_upload.py
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to modify."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    guest_directory:
+      type: string
+      description: "Directory name in the guest to store the file (for example, the result of guest_dir_create)."
+      required: true
+      position: 3
+    local_path:
+      type: string
+      description: "Local path to file being uploaded.  This can be a full path understood by the StackStorm runtime, or a path relative to the packs directory when prefixed with 'pack:'."
+      required: true
+      position: 4
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 5
+      default: ~
+

--- a/actions/guest_process_run.yaml
+++ b/actions/guest_process_run.yaml
@@ -1,0 +1,49 @@
+---
+  name: guest_process_run
+  runner_type: orquesta
+  entry_point: workflows/guest_process_run.yaml
+  enabled: true
+  description: "Run a process inside the guest."
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to modify."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    command:
+      type: string
+      description: "Full path to command executable in the guest."
+      required: true
+      position: 3
+    argument:
+      type: array 
+      description: "Argument(s) to pass to the command executable."
+      required: false
+      position: 4
+    workdir:
+      type: string
+      description: "Working directory for the new process."
+      required: false
+      position: 5
+    envvar:
+      type: array
+      description: "Environment variable(s) for the new process, of the form VARIABLE=VALUE."
+      required: false
+      position: 6
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 7
+      default: ~

--- a/actions/guest_process_start.py
+++ b/actions/guest_process_start.py
@@ -1,0 +1,48 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.guest import GuestAction
+from pyVmomi import vim  # pylint: disable-msg=E0611
+
+
+class StartProgramInGuest(GuestAction):
+
+    def run(self, vm_id, username, password, command, arguments, workdir,
+            envvar, vsphere=None):
+        """
+        Execute a program inside a guest.
+
+        Args:
+        - vm_id: MOID of the Virtual Machine
+        - username: username to perform the operation
+        - password: password of that user
+        - command: command to run
+        - arguments: [optional] command argument(s)
+        - workdir: [optional] working directory
+        - envvar: [optional] [array] environment variable(s)
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+        """
+        self.prepare_guest_operation(vsphere, vm_id, username, password)
+        cmdargs = arguments
+        if not cmdargs:
+            cmdargs = ''
+        cmdspec = vim.vm.guest.ProcessManager.ProgramSpec(
+            arguments=cmdargs,
+            envVariables=envvar,
+            programPath=command,
+            workingDirectory=workdir)
+        print(cmdspec)
+        return self.guest_process_manager.StartProgramInGuest(
+            self.vm, self.guest_credentials, cmdspec)

--- a/actions/guest_process_start.yaml
+++ b/actions/guest_process_start.yaml
@@ -1,0 +1,50 @@
+---
+  name: guest_process_start
+  runner_type: python-script
+  description: "Start a process inside the guest."
+  enabled: true
+  entry_point: guest_process_start.py
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to run the process within."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    command:
+      type: string
+      description: "Command to execute."
+      required: true
+      position: 3
+    arguments:
+      type: string
+      description: "Argument(s) to the command."
+      required: false
+      position: 4
+    workdir:
+      type: string
+      description: "Working directory for new process."
+      required: false
+      position: 5
+    envvar:
+      type: array
+      description: "Environment variable(s) (key=value)."
+      required: false
+      position: 6
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 7
+      default: ~
+

--- a/actions/guest_process_wait.py
+++ b/actions/guest_process_wait.py
@@ -1,0 +1,47 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.guest import GuestAction
+import eventlet
+import sys
+
+
+class WaitForProgramInGuest(GuestAction):
+
+    def run(self, vm_id, username, password, pid, vsphere=None):
+        """
+        Wait for a program to exit in the guest.
+
+        Args:
+        - vm_id: MOID of the Virtual Machine
+        - username: username to perform the operation
+        - password: password of that user
+        - pid: process id
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+        """
+        self.prepare_guest_operation(vsphere, vm_id, username, password)
+        delay = 1
+        max_delay = 8
+        while True:
+            inf = self.guest_process_manager.ListProcessesInGuest(
+                vm=self.vm, auth=self.guest_credentials, pids=[pid])
+            if not inf:
+                raise Exception("No such process: " + str(pid))
+            elif inf[0].endTime is not None:
+                print(inf[0])
+                sys.exit(inf[0].exitCode)
+            else:
+                eventlet.sleep(delay)
+                delay = min(delay * 2, max_delay)

--- a/actions/guest_process_wait.yaml
+++ b/actions/guest_process_wait.yaml
@@ -1,0 +1,35 @@
+---
+  name: guest_process_wait
+  runner_type: python-script
+  description: "Wait for a process inside the guest to exit."
+  enabled: true
+  entry_point: guest_process_wait.py
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to run the process within."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    pid:
+      type: integer
+      description: "Process ID to wait for."
+      required: true
+      position: 3
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 4
+      default: ~
+

--- a/actions/guest_script_run.yaml
+++ b/actions/guest_script_run.yaml
@@ -1,0 +1,49 @@
+---
+  name: guest_script_run
+  runner_type: orquesta
+  entry_point: workflows/guest_script_run.yaml
+  enabled: true
+  description: "Run a script inside the guest."
+  parameters:
+    vm_id:
+      type: string
+      description: "VM to modify."
+      required: true
+      position: 0
+    username:
+      type: string
+      description: "Username within the guest to perform the action."
+      required: true
+      position: 1
+    password:
+      type: string
+      description: "Password for the given username."
+      required: true
+      secret: true
+      position: 2
+    interpreter:
+      type: string
+      description: "Full path to script interpreter in the guest.  Interpreter must be able to redirect stdout with 1> and stderr with 2>."
+      required: true
+      position: 3
+    interpreter_arguments:
+      type: string
+      description: "Arguments to pass to the interpreter before the script name."
+      required: false
+      position: 4
+    script:
+      type: string
+      description: "Local path to script.  This can be a full path in StackStorm's runtime context, or if prefixed with 'pack:' then a relative path to the 'packs' directory.  If the current pack is in packs.dev, then 'pack:' will be relative to 'packs.dev'."
+      required: true
+      position: 5
+    script_arguments:
+      type: string
+      description: "Arguments to pass into the script."
+      required: false
+      position: 6
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 7
+      default: ~

--- a/actions/vmwarelib/actions.py
+++ b/actions/vmwarelib/actions.py
@@ -52,8 +52,16 @@ class BaseAction(Action):
                 ssl._create_default_https_context = _create_unverified_https_context
 
     def establish_connection(self, vsphere):
+        """
+        Sets:
+        - content
+        """
         self.si = self._connect(vsphere)
         self.si_content = self.si.RetrieveContent()
+
+    @property
+    def content(self):
+        return self.si_content
 
     def _connect(self, vsphere):
         if vsphere:

--- a/actions/vmwarelib/guest.py
+++ b/actions/vmwarelib/guest.py
@@ -1,0 +1,88 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from actions import BaseAction
+from pyVmomi import vim  # pylint: disable-msg=E0611
+import inventory
+import os
+
+
+class GuestAction(BaseAction):
+    """
+    GuestAction configures typical settings and properties to
+    execute a Guest Operations command against a single VM.
+    """
+    def prepare_guest_operation(self, vsphere, vm_id, username, password):
+        """
+        Args:
+        - vsphere: The pre-configured vSphere connection details.
+        - vm_id: The MOID of the VM.
+        - username: The username within the VM.
+        - password: The password for that username.
+
+        Configures Properties:
+        - content
+        - guest_credentials
+        - guest_file_manager
+        - guest_operations_manager
+        - guest_process_manager
+        - vm
+        """
+        self.establish_connection(vsphere)
+        self._creds = self._auth_username_password(username=username,
+                                                   password=password)
+        self._vm = inventory.get_virtualmachine(self.content, moid=vm_id)
+
+    @property
+    def guest_credentials(self):
+        return self._creds
+
+    @property
+    def guest_file_manager(self):
+        return self.guest_operations_manager.fileManager
+
+    @property
+    def guest_operations_manager(self):
+        return self.si_content.guestOperationsManager
+
+    @property
+    def guest_process_manager(self):
+        return self.guest_operations_manager.processManager
+
+    @property
+    def vm(self):
+        return self._vm
+
+    def joinpath(self, path, nxt):
+        """
+        os.path.join makes assumptions based on the OS of the
+        caller.  In this case we may be dealing with a path from
+        a foreign OS.  If the path contains a colon followed
+        by a backslash (NOTE: this is perfectly legal in POSIX)
+        we assume it is for Windows.
+
+        Args:
+        - path: the left part of the path
+        - nxt: the next element to append to the path
+
+        Returns:
+        - A full path
+        """
+        sep = "\\" if ":\\" in path else os.sep
+        return path.rstrip(sep) + sep + nxt.strip(sep)
+
+    def _auth_username_password(self, username=None, password=None):
+        return vim.vm.guest.NamePasswordAuthentication(username=username,
+                                                       password=password)

--- a/actions/vmwarelib/inventory.py
+++ b/actions/vmwarelib/inventory.py
@@ -105,7 +105,7 @@ def get_distributedportgroup(content, moid=None, name=None):
 
 def get_virtualmachine(content, moid=None, name=None):
     return get_managed_entity(content, vim.VirtualMachine,
-                              moid=moid, name=name)
+                            moid=moid, name=name)
 
 
 def get_virtualmachines(content):

--- a/actions/workflows/guest_script_run.yaml
+++ b/actions/workflows/guest_script_run.yaml
@@ -1,0 +1,123 @@
+version: '1.0'
+
+description: Run a script inside a guest.
+
+input:
+  - vm_id
+  - username
+  - password
+  - interpreter
+  - interpreter_arguments
+  - script
+  - script_arguments
+  - vsphere
+
+vars:
+  - script_exit_code: -1
+  - script_in_guest: ''
+  - script_stdout: ''
+  - script_stderr: ''
+  - tempdir: ''
+
+output:
+  - exit_code: <% ctx().script_exit_code %>
+  - stderr: <% ctx().script_stderr %>
+  - stdout: <% ctx().script_stdout %>
+
+tasks:
+  dir_create:
+    action: vsphere.guest_dir_create
+    input:
+      vm_id: <% ctx().vm_id %>
+      username: <% ctx().username %>
+      password: <% ctx().password %>
+      prefix: "stackstorm_"
+      suffix: "_scriptrunner"
+      vsphere: <% ctx().vsphere %>
+    next:
+      - when: <% succeeded() %>
+        publish: tempdir=<% result().result %>
+        do: file_upload
+
+  file_upload:
+    action: vsphere.guest_file_upload
+    input:
+      vm_id: <% ctx().vm_id %>
+      username: <% ctx().username %>
+      password: <% ctx().password %>
+      guest_directory: <% ctx().tempdir %>
+      local_path: <% ctx().script %>
+      vsphere: <% ctx().vsphere %>
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - script_in_guest: <% result().result %>
+        do: process_start
+      - when: <% failed() %>
+        do: dir_delete
+
+  process_start:
+    action: vsphere.guest_process_start
+    input:
+      vm_id: <% ctx().vm_id %>
+      username: <% ctx().username %>
+      password: <% ctx().password %>
+      command: <% ctx().interpreter %>
+      arguments: <% ctx().interpreter_arguments %> <% ctx().script_in_guest %> <% ctx().script_arguments %> 1> stdout 2> stderr
+      workdir: <% ctx().tempdir %>
+      vsphere: <% ctx().vsphere %>
+    next:
+      - when: <% succeeded() %>
+        publish: pid=<% result().result %>
+        do: process_wait
+      - when: <% failed() %>
+        do: dir_delete
+
+  process_wait:
+    action: vsphere.guest_process_wait
+    input:
+      vm_id: <% ctx().vm_id %>
+      username: <% ctx().username %>
+      password: <% ctx().password %>
+      pid: <% ctx().pid %>
+    next:
+      - publish: script_exit_code=<% result().exit_code %>
+        do: get_stdout
+
+  get_stdout:
+    action: vsphere.guest_file_read
+    input:
+      vm_id: <% ctx().vm_id %>
+      username: <% ctx().username %>
+      password: <% ctx().password %>
+      guest_directory: <% ctx().tempdir %>
+      guest_file: <% stdout %>
+    next:
+      - publish: script_stdout=<% result().result %>
+        do: get_stderr
+
+  get_stderr:
+    action: vsphere.guest_file_read
+    input:
+      vm_id: <% ctx().vm_id %>
+      username: <% ctx().username %>
+      password: <% ctx().password %>
+      guest_directory: <% ctx().tempdir %>
+      guest_file: <% stderr %>
+    next:
+      - publish: script_stderr=<% result().result %>
+        do: dir_delete
+
+  dir_delete:
+    action: vsphere.guest_dir_delete
+    input:
+      vm_id: <% ctx().vm_id %>
+      username: <% ctx().username %>
+      password: <% ctx().password %>
+      guest_directory: <% ctx().tempdir %>
+      recursive: true
+      vsphere: <% ctx().vsphere %>
+    next:
+      - when: <% ctx().script_exit_code != 0 %>
+        do: fail
+      

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,7 @@
 ref: vsphere
 name: vsphere 
 description: VMware vSphere
+stackstorm_version: ">=2.9.0"
 version: 0.7.7
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com

--- a/tests/test_action_guest_dir_create.py
+++ b/tests/test_action_guest_dir_create.py
@@ -1,0 +1,38 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from guest_dir_create import CreateTemporaryDirectoryInGuest
+
+__all__ = [
+    'CreateTemporaryDirectoryInGuestTestCase'
+]
+
+
+class CreateTemporaryDirectoryInGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = CreateTemporaryDirectoryInGuest
+
+    def test_normal(self):
+        (action, mock_vm) = self.mock_one_vm('vm-12345')
+        mockFileMgr = mock.Mock()
+        mockFileMgr.CreateTemporaryDirectoryInGuest = mock.Mock()
+        mockFileMgr.CreateTemporaryDirectoryInGuest.return_value = '/tmp/foo'
+        action.si_content.guestOperationsManager = mock.Mock()
+        action.si_content.guestOperationsManager.fileManager = mockFileMgr
+        result = action.run(vm_id='vm-12345', username='u', password='p',
+                            prefix='p', suffix='s')
+        mockFileMgr.CreateTemporaryDirectoryInGuest.assert_called_once()
+        self.assertEqual(result, '/tmp/foo')

--- a/tests/test_action_guest_dir_delete.py
+++ b/tests/test_action_guest_dir_delete.py
@@ -1,0 +1,37 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from guest_dir_delete import DeleteDirectoryInGuest
+
+__all__ = [
+    'DeleteDirectoryInGuestTestCase'
+]
+
+
+class DeleteDirectoryInGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = DeleteDirectoryInGuest
+
+    def test_normal(self):
+        (action, mock_vm) = self.mock_one_vm('vm-12345')
+        mockFileMgr = mock.Mock()
+        mockFileMgr.DeleteDirectoryInGuest = mock.Mock()
+        action.si_content.guestOperationsManager = mock.Mock()
+        action.si_content.guestOperationsManager.fileManager = mockFileMgr
+        result = action.run(vm_id='vm-12345', username='u', password='p',
+                            guest_directory='/tmp/foo', recursive=True)
+        mockFileMgr.DeleteDirectoryInGuest.assert_called_once()
+        self.assertEqual(result, None)

--- a/tests/test_action_guest_file_create.py
+++ b/tests/test_action_guest_file_create.py
@@ -1,0 +1,38 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from guest_file_create import CreateTemporaryFileInGuest
+
+__all__ = [
+    'CreateTemporaryFileInGuestTestCase'
+]
+
+
+class CreateTemporaryFileInGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = CreateTemporaryFileInGuest
+
+    def test_normal(self):
+        (action, mock_vm) = self.mock_one_vm('vm-12345')
+        mockFileMgr = mock.Mock()
+        mockFileMgr.CreateTemporaryFileInGuest = mock.Mock()
+        mockFileMgr.CreateTemporaryFileInGuest.return_value = '/tmp/foo.txt'
+        action.si_content.guestOperationsManager = mock.Mock()
+        action.si_content.guestOperationsManager.fileManager = mockFileMgr
+        result = action.run(vm_id='vm-12345', username='u', password='p',
+                            guest_directory='d', prefix='p', suffix='s')
+        mockFileMgr.CreateTemporaryFileInGuest.assert_called_once()
+        self.assertEqual(result, '/tmp/foo.txt')

--- a/tests/test_action_guest_file_delete.py
+++ b/tests/test_action_guest_file_delete.py
@@ -1,0 +1,40 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from guest_file_delete import DeleteFileInGuest
+
+__all__ = [
+    'DeleteFileInGuestTestCase'
+]
+
+
+class DeleteFileInGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = DeleteFileInGuest
+
+    def test_normal(self):
+        # test with and without guest_directory:
+        for vars in [(None, '/tmp/foo.txt'), ('/tmp', 'foo.txt')]:
+            (action, mock_vm) = self.mock_one_vm('vm-12345')
+            mockFileMgr = mock.Mock()
+            mockFileMgr.DeleteFileInGuest = mock.Mock()
+            action.si_content.guestOperationsManager = mock.Mock()
+            action.si_content.guestOperationsManager.fileManager = mockFileMgr
+            result = action.run(vm_id='vm-12345', username='u', password='p',
+                                guest_directory=vars[0], guest_file=vars[1])
+            mockFileMgr.DeleteFileInGuest.assert_called_once_with(
+                mock.ANY, mock.ANY, '/tmp/foo.txt')
+            self.assertEqual(result, None)

--- a/tests/test_action_guest_file_read.py
+++ b/tests/test_action_guest_file_read.py
@@ -1,0 +1,57 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from guest_file_read import InitiateFileTransferFromGuest
+
+__all__ = [
+    'InitiateFileTransferFromGuestTestCase'
+]
+
+
+def mocked_requests_get(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, text, status_code):
+            self.text = text
+            self.status_code = status_code
+
+        def raise_for_status(self):
+            pass
+
+    return MockResponse("mocktext", 200)
+
+
+class InitiateFileTransferFromGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = InitiateFileTransferFromGuest
+
+    def test_normal(self):
+        # test with and without guest_directory:
+        for vars in [(None, '/tmp/foo.txt'), ('/tmp', 'foo.txt')]:
+            (action, mock_vm) = self.mock_one_vm('vm-12345')
+            mockFileMgr = mock.Mock()
+            mockFileMgr.InitiateFileTransferFromGuest = mock.Mock()
+            action.si_content.guestOperationsManager = mock.Mock()
+            action.si_content.guestOperationsManager.fileManager = mockFileMgr
+            with mock.patch('requests.get', side_effect=mocked_requests_get):
+                result = action.run(vm_id='vm-12345',
+                                    username='u',
+                                    password='p',
+                                    guest_directory=vars[0],
+                                    guest_file=vars[1])
+                mockFileMgr.InitiateFileTransferFromGuest.\
+                    assert_called_once_with(
+                        mock.ANY, mock.ANY, guestFilePath='/tmp/foo.txt')
+                self.assertEqual(result, "mocktext")

--- a/tests/test_action_guest_file_upload.py
+++ b/tests/test_action_guest_file_upload.py
@@ -1,0 +1,54 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from guest_file_upload import InitiateFileTransferToGuest
+
+__all__ = [
+    'InitiateFileTransferToGuestTestCase'
+]
+
+
+class InitiateFileTransferToGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = InitiateFileTransferToGuest
+
+    @mock.patch('__builtin__.open',
+                mock.mock_open(read_data="mockfilecontents"))
+    @mock.patch('requests.put')
+    def test_normal(self, mock_put):
+        # Exercise guest directory, one Windows, one Linux
+        # guest_path[0] is the input guest_directory
+        # guest_path[1] is the expected result
+        for guest_path in (["C:\\WINDOWS\\TEMP", "C:\\WINDOWS\\TEMP\\myfile"],
+                           ["/tmp", "/tmp/myfile"]):
+            # Exercise both local_path variants
+            for local_path in (
+                '/opt/stackstorm/packs.dev/mypack/myfile',
+                'pack:mypack/myfile'
+            ):
+                (action, mock_vm) = self.mock_one_vm('vm-12345')
+                mockFileMgr = mock.Mock()
+                mockFileMgr.InitiateFileTransferToGuest = mock.Mock()
+                action.si_content.guestOperationsManager = mock.Mock()
+                action.si_content.guestOperationsManager.fileManager =\
+                    mockFileMgr
+                result = action.run(vm_id='vm-12345',
+                                    username='u',
+                                    password='p',
+                                    guest_directory=guest_path[0],
+                                    local_path=local_path)
+                mockFileMgr.InitiateFileTransferToGuest.assert_called_once()
+                self.assertEqual(result, guest_path[1])

--- a/tests/test_action_guest_process_start.py
+++ b/tests/test_action_guest_process_start.py
@@ -1,0 +1,54 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from guest_process_start import StartProgramInGuest
+
+__all__ = [
+    'StartProgramInGuestTestCase'
+]
+
+
+class StartProgramInGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = StartProgramInGuest
+
+    def test_normal(self):
+        # Vary the arguments list including passing None
+        # Each tuple has two array items, [0] is arguments input
+        #                                 [1] is expected cmdspec
+        for argdata in (None, 'onearg', 'two arguments'):
+            (action, mock_vm) = self.mock_one_vm('vm-12345')
+            mockProcMgr = mock.Mock()
+            mockProcMgr.StartProgramInGuest = mock.Mock()
+            mockProcMgr.StartProgramInGuest.return_value = 12345
+            action.si_content.guestOperationsManager = mock.Mock()
+            action.si_content.guestOperationsManager.processManager =\
+                mockProcMgr
+            envvars = ["A=B", "C=D"] if argdata else None
+            result = action.run(vm_id='vm-12345', username='u',
+                                password='p', command='c',
+                                arguments=argdata, workdir='/tmp',
+                                envvar=envvars)
+            mockProcMgr.StartProgramInGuest.assert_called_once()
+            cmdspec = mockProcMgr.StartProgramInGuest.call_args[0][2]
+            self.assertEqual(cmdspec.programPath, 'c')
+            expectedargs = argdata
+            if not expectedargs:
+                expectedargs = ''
+            self.assertEqual(cmdspec.arguments, expectedargs)
+            self.assertEqual(cmdspec.workingDirectory, '/tmp')
+            self.assertEqual(cmdspec.envVariables, envvars)
+            self.assertEqual(result, 12345)

--- a/tests/test_action_guest_process_wait.py
+++ b/tests/test_action_guest_process_wait.py
@@ -1,0 +1,57 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from guest_process_wait import WaitForProgramInGuest
+
+__all__ = [
+    'WaitForProgramInGuestTestCase'
+]
+
+
+class WaitForProgramInGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = WaitForProgramInGuest
+
+    def test_no_such_process(self):
+        (action, mock_vm) = self.mock_one_vm('vm-12345')
+        mockProcMgr = mock.Mock()
+        mockProcMgr.ListProcessesInGuest = mock.Mock()
+        mockProcMgr.ListProcessesInGuest.return_value = None
+        action.si_content.guestOperationsManager = mock.Mock()
+        action.si_content.guestOperationsManager.processManager = mockProcMgr
+        with self.assertRaises(Exception):
+            action.run(vm_id='vm-12345', username='u', password='p',
+                       pid=12345)
+
+    @mock.patch('eventlet.sleep')
+    def test_wait_normal(self, mock_sleep):
+        (action, mock_vm) = self.mock_one_vm('vm-12345')
+        mockProcMgr = mock.Mock()
+        mockProcMgr.ListProcessesInGuest = mock.Mock()
+        still_running = mock.Mock()
+        still_running.endTime = None
+        finished = mock.Mock()
+        finished.endTime = "yes"
+        finished.exitCode = 42
+        mockProcMgr.ListProcessesInGuest.side_effect =\
+            [[still_running], [still_running], [still_running],
+             [still_running], [still_running], [finished]]
+        action.si_content.guestOperationsManager = mock.Mock()
+        action.si_content.guestOperationsManager.processManager = mockProcMgr
+        with self.assertRaises(SystemExit) as cm:
+            action.run(vm_id='vm-12345', username='u', password='p',
+                       pid=12345)
+        self.assertEqual(cm.exception.code, 42)

--- a/tests/vsphere_base_action_test_case.py
+++ b/tests/vsphere_base_action_test_case.py
@@ -12,8 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
-import yaml
 import json
+import mock
+import yaml
 
 from st2tests.base import BaseActionTestCase
 
@@ -65,6 +66,7 @@ class VsphereBaseActionTestCase(BaseActionTestCase):
     def test_run_config_new(self):
         action = self.get_action_instance(self.new_config)
         self.assertIsInstance(action, self.action_cls)
+        return action
 
     def test_run_config_old_partial(self):
         self.assertRaises(ValueError, self.action_cls, self.old_config_partial)
@@ -73,3 +75,27 @@ class VsphereBaseActionTestCase(BaseActionTestCase):
         action = self.get_action_instance(self.new_config_partial)
         self.assertRaises(KeyError, action.establish_connection,
                           vsphere="default")
+
+    def mock_one_vm(self, vm_id):
+        """
+        Configure a single VM mock.  Helps make writing tests against vm actions easier.
+
+        Args:
+        - vm_id: the MOID to give the mock VM
+
+        Returns:
+        - (action, mock_vm)
+        """
+        action = self.test_run_config_new()
+        action.establish_connection = mock.Mock()
+        action.si_content = mock.Mock()
+        action.si_content.rootFolder = mock.Mock()
+        action.si_content.viewManager = mock.Mock()
+        mock_vm = mock.Mock()
+        mock_vm._moId = vm_id
+        container = mock.Mock()
+        container.view = mock.MagicMock()
+        container.view.__iter__.return_value = [mock_vm]
+        action.si_content.viewManager.CreateContainerView.return_value =\
+            container
+        return (action, mock_vm)


### PR DESCRIPTION
Includes an Orquesta Workflow that allows one to upload and run a script inside a guest and obtain the result (exit code, stdout, stderr).

This has been tested against a Windows guest and has 100% unit test coverage:
```
Name                                   Stmts   Miss  Cover
----------------------------------------------------------
actions/guest_dir_create.py                5      0   100%
actions/guest_dir_delete.py                5      0   100%
actions/guest_file_create.py               5      0   100%
actions/guest_file_delete.py               8      0   100%
actions/guest_file_read.py                12      0   100%
actions/guest_file_upload.py              20      0   100%
actions/guest_process_start.py            11      0   100%
actions/guest_process_wait.py             17      0   100%
actions/vmwarelib/guest.py                24      0   100%
```

With PowerShell it looks like the exit_code is 1 for any non-zero exit code the script returns.  I haven't been able to get the "-File" interpreter argument to work with PowerShell that would allow it to return the error code properly.