### PR TITLE
action: shutdown guest

### DIFF
--- a/actions/vm_shutdown.py
+++ b/actions/vm_shutdown.py
@@ -1,0 +1,37 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib import inventory
+from vmwarelib.actions import BaseAction
+
+
+class VMShutdownGuest(BaseAction):
+
+    def run(self, id, vsphere=None):
+        """
+        Initiate a clean shutdown on one or more VMs.
+
+        Args:
+        - id: [array] MOIDs of Virtual Machines to shutdown.
+        - vsphere: Pre-configured vSphere connection details (config.yaml)
+
+        Returns:
+        - task
+        """
+
+        self.establish_connection(vsphere)
+        for vm_id in id:
+            vm = inventory.get_virtualmachine(self.si_content, moid=vm_id)
+            return vm.ShutdownGuest()

--- a/actions/vm_shutdown.yaml
+++ b/actions/vm_shutdown.yaml
@@ -1,0 +1,19 @@
+---
+  name: "vm_shutdown"
+  runner_type: "python-script"
+  description: "Initiates a clean shutdown of the guest.  Returns immediately without waiting for the guest to complete shutdown."
+# Privilege VirtualMachine.Interact.PowerOff is required
+  enabled: true
+  entry_point: "vm_shutdown.py"
+  parameters:
+    id:
+      type: array
+      description: "VM(s) to shutdown."
+      required: true
+      position: 0
+    vsphere:
+      type: string
+      description: "Pre-configured vSphere connection details."
+      required: false
+      position: 1
+

--- a/tests/test_action_vm_shutdown.py
+++ b/tests/test_action_vm_shutdown.py
@@ -1,0 +1,32 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+from vm_shutdown import VMShutdownGuest
+
+__all__ = [
+    'VMShutdownGuestTestCase'
+]
+
+
+class VMShutdownGuestTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = VMShutdownGuest
+
+    def test_normal(self):
+        (action, mock_vm) = self.mock_one_vm('vm-12345')
+        mock_vm.ShutdownGuest = mock.Mock()
+        action.run(id=['vm-12345'])
+        mock_vm.ShutdownGuest.assert_called_once()


### PR DESCRIPTION
This action initiates VirtualMachine.ShutdownGuest() which is not a task and has no response.  It initiates an orderly guest shutdown but does not wait for the shutdown to complete.  If runtime.powerState is not "poweredOff" this will likely raise an exception (based on the VMware documentation).  One can monitor the runtime.powerState changing to "poweredOff" to wait for the state change.

I also added an easier way to mock a single VM (by MOID) in the tests.
100% code coverage.