### PR TITLE
Update/raise-error-if-moids-not-found

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.8.7
+
+Updated actions:
+* `vsphere.get_moid` - Returns an error if objects aren't found in vSphere
+
+Contributed by John Schoewe (Encore Technologies).
+
 ## v0.8.6
 
 Added new actions:

--- a/actions/get_moid.py
+++ b/actions/get_moid.py
@@ -45,6 +45,6 @@ class GetMoid(BaseAction):
 
         # Raise an error if no MOIDs were found for the VMs
         if not results:
-            raise Exception("Could not find objects with names: {}".format(", ".join(object_names)))
+            return (False, {})
 
         return (True, results)

--- a/actions/get_moid.py
+++ b/actions/get_moid.py
@@ -19,7 +19,8 @@ from vmwarelib.actions import BaseAction
 class GetMoid(BaseAction):
     def run(self, object_names, object_type, vsphere=None):
         """
-        Transform object_name and object_type to MOID (Managed Object Reference ID).
+        Transform object_name and object_type to MOID (Managed Object Reference ID). If the objects
+        are not found then this action will fail.
 
         Args:
         - object_name: name of object that is labeled to the target

--- a/actions/get_moid.py
+++ b/actions/get_moid.py
@@ -43,4 +43,8 @@ class GetMoid(BaseAction):
             except Exception as e:
                 self.logger.warning(str(e))
 
+        # Raise an error if no MOIDs were found for the VMs
+        if not results:
+            raise Exception("Could not find objects with names: {}".format(", ".join(object_names)))
+
         return (True, results)

--- a/actions/get_moid.yaml
+++ b/actions/get_moid.yaml
@@ -1,7 +1,7 @@
 ---
 name: get_moid
 runner_type: python-script
-description: Returns the MOID of vSphere managed entity corresponding to the specified parameters
+description: Returns the MOID of vSphere managed entity corresponding to the specified parameters. If the corresponding entities are not found then the action will fail.
 enabled: true
 entry_point: get_moid.py
 parameters:

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.8.6
+version: 0.8.7
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/test_action_get_moid.py
+++ b/tests/test_action_get_moid.py
@@ -71,7 +71,8 @@ class GetMoidTestCase(VsphereBaseActionTestCase):
 
         # invoke action with invalid names which don't match any objects
         with mock.patch.object(inventory, 'get_managed_entity', side_effect=side_effect):
-            with self.assertRaises(Exception):
-                self._action.run(object_names=['hoge'], object_type='VirtualMachine')
+            result = self._action.run(object_names=['hoge'], object_type='VirtualMachine')
 
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], {})
         mock_vim_type.assert_called_with('VirtualMachine')

--- a/tests/test_action_get_moid.py
+++ b/tests/test_action_get_moid.py
@@ -71,8 +71,7 @@ class GetMoidTestCase(VsphereBaseActionTestCase):
 
         # invoke action with invalid names which don't match any objects
         with mock.patch.object(inventory, 'get_managed_entity', side_effect=side_effect):
-            result = self._action.run(object_names=['hoge'], object_type='VirtualMachine')
+            with self.assertRaises(Exception):
+                self._action.run(object_names=['hoge'], object_type='VirtualMachine')
 
-        self.assertTrue(result[0])
-        self.assertEqual(result[1], {})
         mock_vim_type.assert_called_with('VirtualMachine')


### PR DESCRIPTION
If no MOIDs were found for the given objects, then this action should fail. Otherwise this causes other actions in a workflow to fail because they are expecting an MOID when the this succeeds.

NOTE: If multiple objects are given and only one of them has an MOID then this action will still succeed. It only fails if no MOIDs are found