### PR TITLE
Feature/add action to remove vm snapshots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## v0.8.8
 
-Added new action:
+Added new actions:
 * `vsphere.vm_snapshots_delete` - Removes any snapshots older than the specified age. Ignores any snapshots with names that match the given rexex patterns
+* `vsphere.vm_bestfit` - Determines the best host and datastore to provision a new VM to on a given cluster
 
 Contributed by John Schoewe (Encore Technologies).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.8.8
+
+Added new action:
+* `vsphere.vm_snapshots_delete` - Removes any snapshots older than the specified age. Ignores any snapshots with names that match the given rexex patterns
+
+Contributed by John Schoewe (Encore Technologies).
+
 ## v0.8.7
 
 Updated actions:

--- a/actions/vm_bestfit.py
+++ b/actions/vm_bestfit.py
@@ -99,24 +99,24 @@ class BestFit(BaseAction):
 
         return datastore
 
-    def filter_datastores(self, datastore_name, datastore_filter_regex):
+    def filter_datastores(self, datastore_name, datastore_filter_regex_list):
         """Check if a datastore should be filtered from the list or not.
         If no regex filters are given then all datastores can be used
         :param datastore_name: Name of the datastore to check filters for
         :param datastore_filter: Array containing list of filters to exclude certain datastores
         :returns boolean: True if the datastore name does NOT match any of the regex expressions
         """
-        if datastore_filter_regex is None:
+        if datastore_filter_regex_list is None:
             return True
 
         # Filter out the datastores by name
         # Include if the datastore name does NOT match any of the regex expressions
-        for regex in datastore_filter_regex:
+        for regex in datastore_filter_regex_list:
             if re.search(regex.strip(), datastore_name):
                 return False
         return True
 
-    def run(self, cluster_name, datastore_filter_regex, disks, vsphere=None):
+    def run(self, cluster_name, datastore_filter_regex_list, disks, vsphere=None):
         """
         Returns a host and datastore name and MOID from the given cluster and filters.
         The result host will be the one with the least amount of VMs and the result
@@ -124,7 +124,7 @@ class BestFit(BaseAction):
 
         Args:
         - cluster_name: Name of the cluster in vSphere to get a host from
-        - datastore_filter_regex: Regular expression to filter the list of available datastores
+        - datastore_filter_regex_list: List of regular expressions to filter the list of datastores
         - disks: List of disks to attach to a new VM
         - vsphere: Pre-Configured vsphere connection details
 
@@ -138,7 +138,7 @@ class BestFit(BaseAction):
 
         # Return a datastore on the host that is either specified in the disks variable or
         # has the most free space and a name that doesn't match any filters
-        datastore = self.get_storage(host, datastore_filter_regex, disks)
+        datastore = self.get_storage(host, datastore_filter_regex_list, disks)
 
         return {'clusterName': host.parent.name,
                 'hostName': host.name,

--- a/actions/vm_bestfit.py
+++ b/actions/vm_bestfit.py
@@ -1,0 +1,145 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from vmwarelib import inventory
+from vmwarelib.actions import BaseAction
+import re
+
+
+class BestFit(BaseAction):
+
+    def __init__(self, config):
+        """Creates a new BaseAction given a StackStorm config object (kwargs works too)
+        :param config: StackStorm configuration object for the pack
+        :returns: a new BaseAction
+        """
+        super(BestFit, self).__init__(config)
+
+    def get_host(self, cluster_name):
+        """Return a host from the given cluster that's powered on and has the least number of VMs
+        :param cluster_name: Name of the cluster to retrieve a host from
+        :returns host_obj: Host object from the given cluster
+        """
+        vimtype = self.get_vim_type("HostSystem")
+
+        hosts = inventory.get_managed_entities(self.si_content, vimtype)
+
+        host_obj = None
+        least_vms = None
+
+        for host in hosts.view:
+            # Need to verify that the host is on, connected, and not in maintenance mode
+            # powerState can be 'poweredOff' 'poweredOn' 'standBy' 'unknown'
+            if (host.parent.name == cluster_name and
+                    host.runtime.powerState == 'poweredOn' and
+                    host.runtime.inMaintenanceMode is False):
+                # Find the host that has the least number of VMs on it
+                if (least_vms is None or len(host.vm) < least_vms):
+                    host_obj = host
+                    least_vms = len(host.vm)
+
+        if host_obj is not None:
+            return host_obj
+        else:
+            raise Exception("No available hosts found for cluster: {}".format(cluster_name))
+
+    def get_storage(self, host, datastore_filter, disks):
+        """Return a datastore on the host that is either specified in the disks variable or
+        has the most free space and a name that doesn't match any filters
+        :param host: Host object to retrieve a datastore from
+        :param datastore_filter: Object containing list of filtersto exclude certain datastores
+          :example: ["string1", "string2"]
+        :param disks: Object containing a list of disks to add to the VM
+          :example:
+            [{
+               "size_gb": "string",
+               "uuid": "string",
+               "datastore": "string",
+               "controller_bus": "string",
+               "scsi_bus": "string"
+            }]
+        :returns datastore: Datastore object from the given host
+        """
+        datastore = None
+
+        # First check the disks variable for a datastotre to use
+        if disks is not None:
+            first_disk = disks[0]
+            datastore_name = first_disk['datastore']
+            if datastore_name != "automatic":
+                vimtype = self.get_vim_type("Datastore")
+                datastore = inventory.get_managed_entity(self.si_content, vimtype,
+                                                         name=datastore_name)
+
+        # If the disks variable is empty or the datastore is set to "automatic" then search
+        # the available datastores on the host for the one with the most free space
+        if datastore is None:
+            storages = host.datastore
+            most_space = 0
+            for ds in storages:
+                # The following function returns False if the name of the datastore
+                # matches any of the regex filters
+                if self.filter_datastores(ds.name, datastore_filter):
+                    if ds.info.freeSpace > most_space:
+                        datastore = ds
+                        most_space = ds.info.freeSpace
+
+        return datastore
+
+    def filter_datastores(self, datastore_name, datastore_filter_regex):
+        """Check if a datastore should be filtered from the list or not.
+        If no regex filters are given then all datastores can be used
+        :param datastore_name: Name of the datastore to check filters for
+        :param datastore_filter: Array containing list of filters to exclude certain datastores
+        :returns boolean: True if the datastore name does NOT match any of the regex expressions
+        """
+        if datastore_filter_regex is None:
+            return True
+
+        # Filter out the datastores by name
+        # Include if the datastore name does NOT match any of the regex expressions
+        for regex in datastore_filter_regex:
+            if re.search(regex.strip(), datastore_name):
+                return False
+        return True
+
+    def run(self, cluster_name, datastore_filter_regex, disks, vsphere=None):
+        """
+        Returns a host and datastore name and MOID from the given cluster and filters.
+        The result host will be the one with the least amount of VMs and the result
+        datastore will be the one with the most free space
+
+        Args:
+        - cluster_name: Name of the cluster in vSphere to get a host from
+        - datastore_filter_regex: Regular expression to filter the list of available datastores
+        - disks: List of disks to attach to a new VM
+        - vsphere: Pre-Configured vsphere connection details
+
+        Returns:
+        - dict: key value pairs with calculated host and datastore names and ids
+        """
+        self.establish_connection(vsphere)
+
+        # Return a host from the given cluster that's powered on and has the least amount of VMs
+        host = self.get_host(cluster_name)
+
+        # Return a datastore on the host that is either specified in the disks variable or
+        # has the most free space and a name that doesn't match any filters
+        datastore = self.get_storage(host, datastore_filter_regex, disks)
+
+        return {'clusterName': host.parent.name,
+                'hostName': host.name,
+                'hostID': host._moId,
+                'datastoreName': datastore.name,
+                'datastoreID': datastore._moId}

--- a/actions/vm_bestfit.py
+++ b/actions/vm_bestfit.py
@@ -77,6 +77,8 @@ class BestFit(BaseAction):
         if disks is not None:
             first_disk = disks[0]
             datastore_name = first_disk['datastore']
+            # If the disks variable is given and it's datastore key is not "automatic" then
+            # the datastore from the disks variable will be returned
             if datastore_name != "automatic":
                 vimtype = self.get_vim_type("Datastore")
                 datastore = inventory.get_managed_entity(self.si_content, vimtype,

--- a/actions/vm_bestfit.yaml
+++ b/actions/vm_bestfit.yaml
@@ -1,0 +1,38 @@
+---
+name: vm_bestfit
+runner_type: python-script
+description: >
+    This action is used to determine the best host and datastore to provision a new VM to on a given cluster. The result host will be the one with the least amount of VMs and the result datastore will be the one with the most free space.
+enabled: true
+entry_point: vm_bestfit.py
+parameters:
+    cluster_name:
+        type: string
+        description: Name of the cluster in vSphere
+        required: true
+    datastore_filter_regex:
+        type: array
+        items:
+          type: string
+        description: >
+          'Regular expression to filter the list of available datastores
+          ["string1", "string2"]'
+        required: false
+    disks:
+        type: array
+        description: >
+          'List of disks to attach to a new VM
+           [{
+              "size_gb": "string",
+              "uuid": "string",
+              "datastore": "string",
+              "controller_bus": "string",
+              "scsi_bus": "string"
+           }]'
+        required: false
+    vsphere:
+        type: string
+        description: Pre-Configured vsphere connection details
+        required: false
+        position: 1
+        default: ~

--- a/actions/vm_bestfit.yaml
+++ b/actions/vm_bestfit.yaml
@@ -2,7 +2,7 @@
 name: vm_bestfit
 runner_type: python-script
 description: >
-    This action is used to determine the best host and datastore to provision a new VM to on a given cluster. The result host will be the one with the least amount of VMs and the result datastore will be the one with the most free space.
+    This action is used to determine the best host and datastore to provision a new VM to on a given cluster
 enabled: true
 entry_point: vm_bestfit.py
 parameters:
@@ -15,14 +15,14 @@ parameters:
         items:
           type: string
         description: >
-          'Regular expression to filter the list of available datastores
-          ["string1", "string2"]'
+          'Regular expressions to filter the list of available datastores. If a datastore name matches any one of these expressions then it will not be returned by this action.
+          example: ["(?i)(backup)", "ds_name"] this will filter out any datastores called "ds_name" as well as any with "backup" in their name'
         required: false
     disks:
         type: array
         description: >
-          'List of disks to attach to a new VM
-           [{
+          'List of disks to attach to a new VM. If a disk isn't given or if it's datastore key is "automatic" then this action will return the name and ID of the datastore with the most free space on it. If the first disk has a datastore that isn't "automatic" then that datastore name and ID will be returned.
+          example: [{
               "size_gb": "string",
               "uuid": "string",
               "datastore": "string",

--- a/actions/vm_bestfit.yaml
+++ b/actions/vm_bestfit.yaml
@@ -10,7 +10,7 @@ parameters:
         type: string
         description: Name of the cluster in vSphere
         required: true
-    datastore_filter_regex:
+    datastore_filter_regex_list:
         type: array
         items:
           type: string

--- a/actions/vm_snapshots_delete.py
+++ b/actions/vm_snapshots_delete.py
@@ -1,0 +1,135 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.actions import BaseAction
+from vmwarelib import inventory
+import re
+import datetime
+import pytz
+
+
+class VMSnapshotsDelete(BaseAction):
+    def delete_old_snapshots(self, snapshot_list, max_age_days, name_ignore_patterns):
+        """Deletes all snapshots from the given list that are older than max_age_days.
+        Ignorning any snapshot with a name that matches one of the name_ignore_pattern.
+        """
+        date_now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+
+        deleted_snapshots = []
+        ignored_snapshots = []
+
+        for snap in snapshot_list:
+            # remove_date is the date the snapshot was created plus max_age_days
+            # Any snapshots older than remove_date will be deleted unless its name includes
+            # an item from name_ignore_patterns
+            remove_date = snap.createTime + datetime.timedelta(days=max_age_days)
+
+            # ignore if the snapshot name matches one of the regexes
+            if self.matches_pattern_list(snap.name, name_ignore_patterns):
+                ignored_snapshots.append("{0}: {1}".format(snap.vm.name, snap.name))
+
+            # Snapshots older than the max age will be deleted
+            elif remove_date < date_now:
+                deleted_snapshots.append("{0}: {1}".format(snap.vm.name, snap.name))
+                snap.snapshot.RemoveSnapshot_Task(removeChildren=False, consolidate=True)
+
+            # Re-run this function with the child snapshot list of any children are found
+            if snap.childSnapshotList:
+                child_result = self.delete_old_snapshots(snap.childSnapshotList,
+                                                         max_age_days,
+                                                         name_ignore_patterns)
+
+                # Append the results from the child snapshots
+                deleted_snapshots += child_result['deleted_snapshots']
+                ignored_snapshots += child_result['ignored_snapshots']
+
+        return {'deleted_snapshots': deleted_snapshots,
+                'ignored_snapshots': ignored_snapshots}
+
+    def delete_all_old_snapshots(self, max_age_days, name_ignore_patterns):
+        """Deletes all snapshots from all VMs that are older than max_age_days.
+        Ignorning any snapshot with a name that matches one of the name_ignore_pattern.
+        """
+        # Retrieve a list of all VMs in vSphere
+        vm_list = inventory.get_virtualmachines(self.si_content)
+        deleted_snapshots = []
+        ignored_snapshots = []
+        for vm in vm_list.view:
+            # Check if any snapshots exist on the VM
+            try:
+                snapshots = vm.snapshot.rootSnapshotList
+            except:
+                continue
+
+            result = self.delete_old_snapshots(snapshots, max_age_days, name_ignore_patterns)
+            # Append the results from each VM
+            deleted_snapshots += result['deleted_snapshots']
+            ignored_snapshots += result['ignored_snapshots']
+
+        return {'deleted_snapshots': deleted_snapshots,
+                'ignored_snapshots': ignored_snapshots}
+
+    def compile_regexes(self, regex_list):
+        """Compiles all of the regexes in the list into patterns
+        :returns: list of compiled patterns
+        """
+        patterns = []
+        for r in regex_list:
+            patterns.append(re.compile(r))
+        return patterns
+
+    def matches_pattern_list(self, name, pattern_list):
+        """Compares the name to each pattern in the list
+        :returns: True if the name matches any of the patterns. False if nothing matches.
+        """
+        for p in pattern_list:
+            if p.search(name):
+                return True
+        return False
+
+    def run(self, max_age_days, name_ignore_regexes, vm_id, vm_name, vsphere=None):
+        """
+        Deletes all snapshots that are older than max_age_days on either all VMs or the given VM.
+        Ignore any snapshot with a name that matches one of the name_ignore_regexes.
+
+        Args:
+        - max_age_days: Number of days that a snapshot will exist before getting deleted
+        - name_ignore_regexes: Compares the snapshot name to the regex. If matched, the snapshot
+            will be ignored and NOT deleted
+        - vm_id: Moid of Virtual Machine to retrieve
+        - vm_name: Name of Virtual Machine to retrieve
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+
+        Returns:
+        - dict: Lists of snapshots that were deleted and ignored
+        """
+        self.establish_connection(vsphere)
+
+        ignore_patterns = self.compile_regexes(name_ignore_regexes)
+
+        # If a VM ID or name was given then only remove snapshots from that VM
+        if vm_id or vm_name:
+            vm = inventory.get_virtualmachine(self.si_content, moid=vm_id, name=vm_name)
+
+            # Check if any snapshots exist on the VM
+            try:
+                snapshots = vm.snapshot.rootSnapshotList
+            except:
+                return "No snapshots found for VM: {}".format(vm.name)
+
+            return self.delete_old_snapshots(snapshots, max_age_days, ignore_patterns)
+        # If no VM was given then remove snapshots from all VMs
+        else:
+            return self.delete_all_old_snapshots(max_age_days, ignore_patterns)

--- a/actions/vm_snapshots_delete.yaml
+++ b/actions/vm_snapshots_delete.yaml
@@ -1,0 +1,33 @@
+---
+  name: vm_snapshots_delete
+  runner_type: python-script
+  description: Removes any snapshots older than the specified age. Ignores any snapshots with names that match the given rexex patterns
+  entry_point: vm_snapshots_delete.py
+  parameters:
+    max_age_days:
+      type: integer
+      description: Number of days that a snapshot will exist before getting deleted
+      required: true
+      position: 0
+    name_ignore_regexes:
+      type: array
+      description: Compares the snapshot name to the regex. If matched, the snapshot will be ignored and NOT deleted
+      required: false
+      default: []
+      position: 1
+    vm_id:
+      type: string
+      description: VM ID to get the containing folder for
+      required: false
+      position: 2
+    vm_name:
+      type: string
+      description: VM Name to get the containing folder for
+      required: false
+      position: 3
+      default: ~
+    vsphere:
+      type: string
+      description: Pre-configured vsphere endpoint
+      required: false
+      position: 4

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.8.7
+version: 0.8.8
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/test_action_vm_bestfit.py
+++ b/tests/test_action_vm_bestfit.py
@@ -1,0 +1,241 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from bestfit import BestFit
+from st2common.runners.base_action import Action
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'BestFitTestCase'
+]
+
+
+class BestFitTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = BestFit
+
+    def setUp(self):
+        super(BestFitTestCase, self).setUp()
+
+        self._action = self.get_action_instance(self.new_config)
+
+        self._action.establish_connection = mock.Mock()
+        self._action.si_content = mock.Mock()
+
+    def test_init(self):
+        action = self.get_action_instance(self.new_config)
+        self.assertIsInstance(action, BestFit)
+        self.assertIsInstance(action, Action)
+
+    def test_filter_datastores_regex_match(self):
+        test_filters = ["(?i)(iso)"]
+        test_name = "dev_isos"
+        expected_result = False
+        result = self._action.filter_datastores(test_name, test_filters)
+        self.assertEqual(expected_result, result)
+
+    def test_filter_datastores_regex_no_match(self):
+        test_filters = ["(?i)(iso)"]
+        test_name = "testdatastore"
+        expected_result = True
+        result = self._action.filter_datastores(test_name, test_filters)
+        self.assertEqual(expected_result, result)
+
+    def test_filter_datastores_name_match(self):
+        test_filters = ["dev_isos"]
+        test_name = "dev_isos"
+        expected_result = False
+        result = self._action.filter_datastores(test_name, test_filters)
+        self.assertEqual(expected_result, result)
+
+    def test_filter_datastores_name_no_match(self):
+        test_filters = ["dev_isos"]
+        test_name = "testdatastore"
+        expected_result = True
+        result = self._action.filter_datastores(test_name, test_filters)
+        self.assertEqual(expected_result, result)
+
+    @mock.patch('vmwarelib.inventory.get_managed_entities')
+    @mock.patch('vmwarelib.actions.BaseAction.get_vim_type')
+    def test_get_host_none_available(self, mock_vim_type, mock_entities):
+        test_cluster_name = "cls1"
+        test_vim_type = "vimType"
+        mock_vim_type.return_value = test_vim_type
+
+        # Mock function results
+        mock_host1 = mock.MagicMock()
+        mock_host1.parent.name = "cls2"
+
+        mock_host2 = mock.MagicMock()
+        mock_host2.parent.name = "cls1"
+        mock_host2.runtime.powerState = "poweredOff"
+
+        # Mock a list of 2 hosts that are unavailable
+        test_host_list = [mock_host1, mock_host2]
+        mock_host_list = mock.MagicMock(view=test_host_list)
+        mock_entities.return_value = mock_host_list
+
+        with self.assertRaises(Exception):
+            self._action.get_host(test_cluster_name)
+
+            mock_entities.assert_called_with(self._action.si_content, test_vim_type)
+
+    @mock.patch('vmwarelib.inventory.get_managed_entities')
+    @mock.patch('vmwarelib.actions.BaseAction.get_vim_type')
+    def test_get_host(self, mock_vim_type, mock_entities):
+        test_cluster_name = "cls1"
+        test_vim_type = "vimType"
+        mock_vim_type.return_value = test_vim_type
+
+        # Mock function results
+        mock_host1 = mock.MagicMock()
+        mock_host1.parent.name = "cls1"
+        mock_host1.runtime.powerState = "poweredOn"
+        mock_host1.runtime.inMaintenanceMode = False
+        mock_host1.vm = ["vm1", "vm2"]
+
+        mock_host2 = mock.MagicMock()
+        mock_host2.parent.name = "cls1"
+        mock_host2.runtime.powerState = "poweredOn"
+        mock_host2.runtime.inMaintenanceMode = False
+        # This host will be the expected result since it has the fewest VMs
+        mock_host2.vm = ["vm1"]
+
+        # Mock a list of 2 hosts that are unavailable
+        test_host_list = [mock_host1, mock_host2]
+        mock_host_list = mock.MagicMock(view=test_host_list)
+        mock_entities.return_value = mock_host_list
+
+        result = self._action.get_host(test_cluster_name)
+
+        self.assertEqual(result, mock_host2)
+        mock_entities.assert_called_with(self._action.si_content, test_vim_type)
+
+    @mock.patch('vmwarelib.inventory.get_managed_entity')
+    @mock.patch('vmwarelib.actions.BaseAction.get_vim_type')
+    def test_get_storage_not_found(self, mock_vim_type, mock_entity):
+        test_vim_type = "vimType"
+        mock_vim_type.return_value = test_vim_type
+
+        test_host = mock.MagicMock()
+        test_datastore_filter = ["filter"]
+        test_disks = [{"datastore": "fail"}]
+
+        # invoke action with invalid names which don't match any objects
+        mock_entity.side_effect = Exception("Inventory Error: Unable to Find Object in a test")
+        with self.assertRaises(Exception):
+            self._action.get_storage(test_host, test_datastore_filter, test_disks)
+
+    @mock.patch('vmwarelib.inventory.get_managed_entity')
+    @mock.patch('vmwarelib.actions.BaseAction.get_vim_type')
+    def test_get_storage_from_disk(self, mock_vim_type, mock_entity):
+        test_vim_type = "vimType"
+        mock_vim_type.return_value = test_vim_type
+
+        test_datastore_filter = ["filter"]
+        test_disks = [{"datastore": "test-ds-1"}]
+
+        expected_result = "result"
+
+        mock_host = mock.MagicMock()
+
+        mock_entity.return_value = expected_result
+
+        result = self._action.get_storage(mock_host, test_datastore_filter, test_disks)
+
+        self.assertEqual(expected_result, result)
+        mock_entity.assert_called_with(self._action.si_content, test_vim_type, name="test-ds-1")
+
+    @mock.patch('bestfit.BestFit.filter_datastores')
+    @mock.patch('vmwarelib.actions.BaseAction.get_vim_type')
+    def test_get_storage_no_disk(self, mock_vim_type, mock_filter):
+        test_vim_type = "vimType"
+        mock_vim_type.return_value = test_vim_type
+
+        test_datastore_filter = ["(?i)(filter)"]
+        test_disks = None
+
+        # Mock datastore objects
+        mock_ds1 = mock.MagicMock()
+        type(mock_ds1).name = mock.PropertyMock(return_value="test-ds-1")
+        mock_ds1.info.freeSpace = 10
+
+        mock_ds2 = mock.MagicMock()
+        type(mock_ds2).name = mock.PropertyMock(return_value="test-ds-2")
+        mock_ds2.info.freeSpace = 20
+
+        # This datastre should get filtered out from test_datastore_filter
+        mock_ds3 = mock.MagicMock()
+        type(mock_ds3).name = mock.PropertyMock(return_value="test-ds-filter")
+        mock_ds3.info.freeSpace = 100
+
+        # This is the result from filter_datastores function that filters out mock_ds3
+        mock_filter.side_effect = [True, True, False]
+
+        # Mock a list of 2 hosts that are unavailable
+        test_ds_list = [mock_ds1, mock_ds2, mock_ds3]
+
+        # Mock host input
+        mock_host = mock.MagicMock(datastore=test_ds_list)
+
+        result = self._action.get_storage(mock_host, test_datastore_filter, test_disks)
+
+        self.assertEqual(result, mock_ds2)
+        mock_filter.assert_has_calls([mock.call("test-ds-1", test_datastore_filter),
+                                      mock.call("test-ds-2", test_datastore_filter),
+                                      mock.call("test-ds-filter", test_datastore_filter)])
+
+    @mock.patch('bestfit.BestFit.get_storage')
+    @mock.patch('bestfit.BestFit.get_host')
+    def test_run(self, mock_get_host, mock_get_storage):
+        # Define test variables
+        test_ds_filter = ["filter"]
+        test_disks = [{"datastore": "test-ds-1"}]
+        test_vsphere = "vsphere"
+
+        test_cluster_name = "test-cluster"
+        test_host_name = "test-host"
+        test_host_id = "host-123"
+        test_ds_name = "test-ds"
+        test_ds_id = "ds-123"
+
+        self._action.establish_connection = mock.Mock()
+
+        # Mock host and datastore result objects
+        mock_host = mock.MagicMock()
+        type(mock_host).name = mock.PropertyMock(return_value=test_host_name)
+        mock_host.parent.name = test_cluster_name
+        mock_host._moId = test_host_id
+
+        mock_get_host.return_value = mock_host
+
+        mock_ds = mock.MagicMock()
+        type(mock_ds).name = mock.PropertyMock(return_value=test_ds_name)
+        mock_ds._moId = test_ds_id
+
+        mock_get_storage.return_value = mock_ds
+
+        expected_result = {'clusterName': test_cluster_name,
+                           'hostName': test_host_name,
+                           'hostID': test_host_id,
+                           'datastoreName': test_ds_name,
+                           'datastoreID': test_ds_id}
+
+        result = self._action.run(test_cluster_name, test_ds_filter, test_disks, test_vsphere)
+
+        self.assertEqual(result, expected_result)
+        self._action.establish_connection.assert_called_with(test_vsphere)
+        mock_get_host.assert_called_with(test_cluster_name)
+        mock_get_storage.assert_called_with(mock_host, test_ds_filter, test_disks)

--- a/tests/test_action_vm_bestfit.py
+++ b/tests/test_action_vm_bestfit.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 
 import mock
-from bestfit import BestFit
+from vm_bestfit import BestFit
 from st2common.runners.base_action import Action
 from vsphere_base_action_test_case import VsphereBaseActionTestCase
 
@@ -158,7 +158,7 @@ class BestFitTestCase(VsphereBaseActionTestCase):
         self.assertEqual(expected_result, result)
         mock_entity.assert_called_with(self._action.si_content, test_vim_type, name="test-ds-1")
 
-    @mock.patch('bestfit.BestFit.filter_datastores')
+    @mock.patch('vm_bestfit.BestFit.filter_datastores')
     @mock.patch('vmwarelib.actions.BaseAction.get_vim_type')
     def test_get_storage_no_disk(self, mock_vim_type, mock_filter):
         test_vim_type = "vimType"
@@ -197,8 +197,8 @@ class BestFitTestCase(VsphereBaseActionTestCase):
                                       mock.call("test-ds-2", test_datastore_filter),
                                       mock.call("test-ds-filter", test_datastore_filter)])
 
-    @mock.patch('bestfit.BestFit.get_storage')
-    @mock.patch('bestfit.BestFit.get_host')
+    @mock.patch('vm_bestfit.BestFit.get_storage')
+    @mock.patch('vm_bestfit.BestFit.get_host')
     def test_run(self, mock_get_host, mock_get_storage):
         # Define test variables
         test_ds_filter = ["filter"]

--- a/tests/test_action_vm_snapshots_delete.py
+++ b/tests/test_action_vm_snapshots_delete.py
@@ -1,0 +1,256 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+from vm_snapshots_delete import VMSnapshotsDelete
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+import re
+
+__all__ = [
+    'VMSnapshotsDeleteTestCase'
+]
+
+
+class VMSnapshotsDeleteTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = VMSnapshotsDelete
+
+    def setUp(self):
+        super(VMSnapshotsDeleteTestCase, self).setUp()
+
+        self._action = self.get_action_instance(self.new_config)
+
+        self._action.establish_connection = mock.Mock()
+        self._action.si_content = mock.Mock()
+
+    @mock.patch('vm_snapshots_delete.re.compile')
+    def test_compile_regexes(self, mock_compile):
+        # def test_compile_regexes(self):
+        test_regex_list = ["REGEX1", "REGEX2"]
+        expected_result = ["PATTERN1", "PATTERN2"]
+        mock_compile.side_effect = expected_result
+        result = self._action.compile_regexes(test_regex_list)
+
+        self.assertEqual(result, expected_result)
+
+        calls = [mock.call("REGEX1"), mock.call("REGEX2")]
+        mock_compile.assert_has_calls(calls)
+
+    def test_matches_pattern_list_true(self):
+        test_pattern_list = [re.compile("PATTERN1"), re.compile("PATTERN2")]
+        test_name = "testsnap_PATTERN2"
+        result = self._action.matches_pattern_list(test_name, test_pattern_list)
+        self.assertEqual(result, True)
+
+    def test_matches_pattern_list_false(self):
+        test_pattern_list = [re.compile("PATTERN1"), re.compile("PATTERN2")]
+        test_name = "testsnap"
+        result = self._action.matches_pattern_list(test_name, test_pattern_list)
+        self.assertEqual(result, False)
+
+    @mock.patch('vm_snapshots_delete.datetime')
+    @mock.patch('vmwarelib.inventory.get_virtualmachines')
+    def test_delete_old_snapshots(self, mock_inventory, mock_datetime):
+        # Define test variables
+        test_max_age_days = 2
+        test_name_ignore_regexes = [re.compile("^.*IGNORE$")]
+
+        # Mock 3 snapshot objects and make one of them a child
+        mock_snap1 = mock.MagicMock(createTime=1)
+        type(mock_snap1).name = mock.PropertyMock(return_value="snap1")
+        mock_snap1.vm.name = "vm1"
+        mock_snap1.snapshot.RemoveSnapshot_Task.return_value = "test"
+
+        mock_snap2 = mock.MagicMock(createTime=1)
+        type(mock_snap2).name = mock.PropertyMock(return_value="snap2")
+        mock_snap2.vm.name = "vm2"
+        mock_snap2.snapshot.RemoveSnapshot_Task.return_value = "test"
+
+        mock_child_snap = mock.MagicMock(createTime=1)
+        type(mock_child_snap).name = mock.PropertyMock(return_value="ignore_snap IGNORE")
+        mock_child_snap.vm.name = "vm3"
+        mock_child_snap.snapshot.RemoveSnapshot_Task.return_value = "test"
+
+        mock_snap2.childSnapshotList = [mock_child_snap]
+
+        mock_datetime.datetime.utcnow().replace.return_value = 3
+        mock_datetime.timedelta.return_value = 1
+
+        # Mock a list of 3 "snapshots"
+        test_snap_list = [mock_snap1, mock_snap2]
+
+        expected_result = {'deleted_snapshots': ["vm1: snap1", "vm2: snap2"],
+                           'ignored_snapshots': ["vm3: ignore_snap IGNORE"]}
+
+        # Run function and verify results
+        result = self._action.delete_old_snapshots(test_snap_list,
+                                                   test_max_age_days,
+                                                   test_name_ignore_regexes)
+
+        self.assertEqual(result, expected_result)
+        mock_datetime.timedelta.assert_called_with(days=test_max_age_days)
+        mock_snap1.snapshot.RemoveSnapshot_Task.assert_called_with(removeChildren=False,
+                                                                   consolidate=True)
+        mock_snap2.snapshot.RemoveSnapshot_Task.assert_called_with(removeChildren=False,
+                                                                   consolidate=True)
+
+    @mock.patch('vm_snapshots_delete.VMSnapshotsDelete.delete_old_snapshots')
+    @mock.patch('vmwarelib.inventory.get_virtualmachines')
+    def test_delete_all_old_snapshots(self, mock_inventory, mock_delete):
+        # Define test variables
+        test_max_age_days = 2
+        test_name_ignore_regexes = ["^.*IGNORE$"]
+
+        expected_result = {'deleted_snapshots': ["snap1", "snap2"],
+                           'ignored_snapshots': []}
+
+        # Mock function results
+        mock_vm1 = mock.MagicMock()
+        mock_vm1.snapshot.rootSnapshotList = ["snap1"]
+
+        mock_vm2 = mock.MagicMock()
+        mock_vm2.snapshot.rootSnapshotList = ["snap2"]
+
+        # Mock a list of 2 VMs with "snapshots" and one without
+        test_vm_list = ["vm_no_snaps", mock_vm1, mock_vm2]
+        mock_vm_list = mock.MagicMock(view=test_vm_list)
+        mock_inventory.return_value = mock_vm_list
+
+        side_effect = [{'deleted_snapshots': ["snap1"], 'ignored_snapshots': []},
+                       {'deleted_snapshots': ["snap2"], 'ignored_snapshots': []}]
+        mock_delete.side_effect = side_effect
+
+        # Run function and verify results
+        result = self._action.delete_all_old_snapshots(test_max_age_days, test_name_ignore_regexes)
+
+        self.assertEqual(result, expected_result)
+        mock_inventory.assert_called_with(self._action.si_content)
+
+        calls = [mock.call(["snap1"], test_max_age_days, test_name_ignore_regexes),
+                 mock.call(["snap2"], test_max_age_days, test_name_ignore_regexes)]
+        mock_delete.assert_has_calls(calls)
+
+    @mock.patch('vm_snapshots_delete.VMSnapshotsDelete.compile_regexes')
+    @mock.patch('vmwarelib.inventory.get_virtualmachine')
+    def test_run_invalid_name(self, mock_inventory, mock_compile_regexes):
+        # Define test variables
+        test_vsphere = "vsphere"
+        test_max_age_days = 2
+        test_name_ignore_regexes = ["^.*IGNORE$"]
+        test_vm_name = "testvm"
+        test_patterns = "test_patterns"
+
+        # Mock function results
+        mock_compile_regexes.return_value = test_patterns
+
+        # invoke action with invalid names which don't match any objects
+        mock_inventory.side_effect = Exception("Inventory Error: Unable to Find Object in a test")
+        with self.assertRaises(Exception):
+            self._action.run(max_age_days=test_max_age_days,
+                             name_ignore_regexes=test_name_ignore_regexes,
+                             vm_id=None,
+                             vm_name=test_vm_name,
+                             vsphere=test_vsphere)
+            mock_inventory.assert_called_with(self._action.si_content, moid=None, name=test_vm_name)
+            mock_compile_regexes.assert_called_with(test_name_ignore_regexes)
+
+    @mock.patch('vm_snapshots_delete.VMSnapshotsDelete.compile_regexes')
+    @mock.patch('vmwarelib.inventory.get_virtualmachine')
+    def test_run_no_snaps(self, mock_inventory, mock_compile_regexes):
+        # Define test variables
+        test_vsphere = "vsphere"
+        test_max_age_days = 2
+        test_name_ignore_regexes = ["^.*IGNORE$"]
+        test_vm_name = "testvm"
+        test_patterns = "test_patterns"
+
+        # Mock function results
+        mock_compile_regexes.return_value = test_patterns
+
+        mock_vm = mock.Mock()
+        mock_inventory.return_value = mock_vm
+        type(mock_vm).name = mock.PropertyMock(return_value=test_vm_name)
+        type(mock_vm).snapshot = mock.PropertyMock(side_effect=ValueError)
+
+        # Run function and verify results
+        result = self._action.run(max_age_days=test_max_age_days,
+                                  name_ignore_regexes=test_name_ignore_regexes,
+                                  vm_id=None,
+                                  vm_name=test_vm_name,
+                                  vsphere=test_vsphere)
+
+        self.assertEqual(result, "No snapshots found for VM: testvm")
+        mock_inventory.assert_called_with(self._action.si_content, moid=None, name=test_vm_name)
+        mock_compile_regexes.assert_called_with(test_name_ignore_regexes)
+
+    @mock.patch('vm_snapshots_delete.VMSnapshotsDelete.compile_regexes')
+    @mock.patch('vm_snapshots_delete.VMSnapshotsDelete.delete_all_old_snapshots')
+    def test_run_all_snaps(self, mock_delete_all_snaps, mock_compile_regexes):
+        # Define test variables
+        test_vsphere = "vsphere"
+        test_max_age_days = 2
+        test_name_ignore_regexes = ["^.*IGNORE$"]
+        test_patterns = "test_patterns"
+
+        # Mock function results
+        mock_compile_regexes.return_value = test_patterns
+
+        expected_result = "result"
+        mock_delete_all_snaps.return_value = expected_result
+
+        # Run function and verify results
+        result = self._action.run(max_age_days=test_max_age_days,
+                                  name_ignore_regexes=test_name_ignore_regexes,
+                                  vm_id=None,
+                                  vm_name=None,
+                                  vsphere=test_vsphere)
+
+        self.assertEqual(result, expected_result)
+        mock_compile_regexes.assert_called_with(test_name_ignore_regexes)
+        mock_delete_all_snaps.assert_called_with(test_max_age_days, test_patterns)
+
+    @mock.patch('vm_snapshots_delete.VMSnapshotsDelete.compile_regexes')
+    @mock.patch('vm_snapshots_delete.VMSnapshotsDelete.delete_old_snapshots')
+    @mock.patch('vmwarelib.inventory.get_virtualmachine')
+    def test_run(self, mock_inventory, mock_delete_snaps, mock_compile_regexes):
+        # Define test variables
+        test_vsphere = "vsphere"
+        test_max_age_days = 2
+        test_name_ignore_regexes = ["^.*IGNORE$"]
+        test_vm_name = "testvm"
+        test_patterns = "test_patterns"
+        test_snap_list = ["test_list"]
+
+        # Mock function results
+        mock_compile_regexes.return_value = test_patterns
+
+        expected_result = "result"
+        mock_delete_snaps.return_value = expected_result
+
+        mock_vm = mock.MagicMock()
+        mock_inventory.return_value = mock_vm
+
+        mock_vm.snapshot.rootSnapshotList = test_snap_list
+
+        # Run function and verify results
+        result = self._action.run(max_age_days=test_max_age_days,
+                                  name_ignore_regexes=test_name_ignore_regexes,
+                                  vm_id=None,
+                                  vm_name=test_vm_name,
+                                  vsphere=test_vsphere)
+
+        self.assertEqual(result, expected_result)
+        mock_inventory.assert_called_with(self._action.si_content, moid=None, name=test_vm_name)
+        mock_delete_snaps.assert_called_with(test_snap_list, test_max_age_days, test_patterns)
+        mock_compile_regexes.assert_called_with(test_name_ignore_regexes)


### PR DESCRIPTION
This action removes any snapshots older than the specified age and ignores any snapshots with names that match the given rexex patterns. It can either delete snapshots on a single given VM or every VM.