### PR TITLE
feature/add-operating-system-to-get_vms-result

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.8.12
+
+Modified action:
+* `vsphere.get_vms` - Added VM operating systems to the result
+
+Contributed by John Schoewe (Encore Technologies).
+
 ## v0.8.11
 
 * Minor linting fixes triggered by updated flake8 versions in CI

--- a/actions/get_vms.py
+++ b/actions/get_vms.py
@@ -36,7 +36,7 @@ class GetVMs(BaseAction):
 
         self.establish_connection(vsphere)
 
-        props = ['name', 'runtime.powerState']
+        props = ['config.guestFullName', 'name', 'runtime.powerState']
         moid_to_vm = {}
 
         # getting vms by their ids
@@ -150,8 +150,9 @@ class GetVMs(BaseAction):
             if vm.obj._GetMoId() not in moid_to_vm:
                 moid_to_vm[vm.obj._GetMoId()] = {
                     "moid": vm.obj._GetMoId(),
-                    "name": vm.propSet[0].val,
-                    "runtime.powerState": vm.propSet[1].val
+                    "name": vm.propSet[1].val,
+                    "os": vm.propSet[0].val,
+                    "runtime.powerState": vm.propSet[2].val
                 }
 
         return moid_to_vm.values()
@@ -163,5 +164,6 @@ class GetVMs(BaseAction):
                 vm_map[vm._GetMoId()] = {
                     "moid": vm._GetMoId(),
                     "name": vm.name,
+                    "os": vm.config.guestFullName,
                     "runtime.powerState": vm.runtime.powerState
                 }

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.8.11
+version: 0.8.12
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:


### PR DESCRIPTION
We would like the ability to filter the results of the get_vms action based on operating system