### PR TITLE
Fix bug in vm_bestfit for "automatic" datastores in Maintenance Mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.9.2
+
+Fixed bug in action `vsphere.custom_attr_get`. It now ignores datastores that are in 
+"maintenance mode" if the datastore name is set to "automatic".
+
+Contributed by Nick Maludy (Encore Technologies).
+
 ## v0.9.1
 
 Added new action:

--- a/actions/vm_bestfit.py
+++ b/actions/vm_bestfit.py
@@ -73,7 +73,7 @@ class BestFit(BaseAction):
         """
         datastore = None
 
-        # First check the disks variable for a datastotre to use
+        # First check the disks variable for a datastore to use
         if disks is not None:
             first_disk = disks[0]
             datastore_name = first_disk['datastore']
@@ -90,6 +90,18 @@ class BestFit(BaseAction):
             storages = host.datastore
             most_space = 0
             for ds in storages:
+                # only allow placing onto a datastore in "normal" mode
+                # this prevents from being placed onto a datastore in "maintenance" mode
+                # Valid values are:
+                #  - enteringMaintenance
+                #  - inMaintenance
+                #  - normal
+                #
+                # https://vdc-repo.vmware.com/vmwb-repository/dcr-public/6b586ed2-655c-49d9-9029-bc416323cb22/fa0b429a-a695-4c11-b7d2-2cbc284049dc/doc/vim.Datastore.Summary.html
+                # https://vdc-repo.vmware.com/vmwb-repository/dcr-public/6b586ed2-655c-49d9-9029-bc416323cb22/fa0b429a-a695-4c11-b7d2-2cbc284049dc/doc/vim.Datastore.Summary.MaintenanceModeState.html
+                if ds.summary.maintenanceMode != 'normal':
+                    continue
+
                 # The following function returns False if the name of the datastore
                 # matches any of the regex filters
                 if self.filter_datastores(ds.name, datastore_filter):

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.9.1
+version: 0.9.2
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/test_action_vm_bestfit.py
+++ b/tests/test_action_vm_bestfit.py
@@ -220,7 +220,7 @@ class BestFitTestCase(VsphereBaseActionTestCase):
         mock_ds2.summary.maintenanceMode = 'inMaintenance'
         mock_ds2.info.freeSpace = 20
 
-        # This datastre should get filtered out from test_datastore_filter
+        # This datastore should get filtered out from test_datastore_filter
         mock_ds3 = mock.MagicMock()
         mock_ds3.name = "test-ds-3"
         mock_ds3.summary.maintenanceMode = 'normal'


### PR DESCRIPTION
Previously vm_bestfit, when requesting an "automatic" datastore, could potentially return a datastore that is in "maintenance mode". 

This caused problems during our provisioning process, because VMware can't write data to a datastore in maintenance mode.

The fix now excludes datastores in maintenance mode when the datastore is "automatic".