### PR TITLE
hotfix/snapshot_remove

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,15 @@
 # Change Log
 
+## v0.9.3
+
+Fixed bug in action `vsphere.vm_snapshots_delete`. Where if there were special charaters
+in the snapshot name vmware automatically encodes them which was causing the action to fail.
+
+Contributed by Bradley Bishop (Encore Technologies).
+
 ## v0.9.2
 
-Fixed bug in action `vsphere.custom_attr_get`. It now ignores datastores that are in 
+Fixed bug in action `vsphere.custom_attr_get`. It now ignores datastores that are in
 "maintenance mode" if the datastore name is set to "automatic".
 
 Contributed by Nick Maludy (Encore Technologies).

--- a/actions/vm_snapshots_delete.py
+++ b/actions/vm_snapshots_delete.py
@@ -36,13 +36,17 @@ class VMSnapshotsDelete(BaseAction):
             # an item from name_ignore_patterns
             remove_date = snap.createTime + datetime.timedelta(days=max_age_days)
 
+            # we need to encode snap shot names because
+            # VM Snapshot 11/13/2019, 9:59:56 AM -> VM Snapshot 11%252f13%252f2019, 9:59:56 AM
+            snap_name = snap.name.encode('utf-8')
+
             # ignore if the snapshot name matches one of the regexes
-            if self.matches_pattern_list(snap.name, name_ignore_patterns):
-                ignored_snapshots.append("{0}: {1}".format(snap.vm.name, snap.name))
+            if self.matches_pattern_list(snap_name, name_ignore_patterns):
+                ignored_snapshots.append("{0}: {1}".format(snap.vm.name, snap_name))
 
             # Snapshots older than the max age will be deleted
             elif remove_date < date_now:
-                deleted_snapshots.append("{0}: {1}".format(snap.vm.name, snap.name))
+                deleted_snapshots.append("{0}: {1}".format(snap.vm.name, snap_name))
                 snap.snapshot.RemoveSnapshot_Task(removeChildren=False, consolidate=True)
 
             # Re-run this function with the child snapshot list of any children are found

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.9.2
+version: 0.9.3
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:


### PR DESCRIPTION
Fixed issue where a snapshot name given in vmware is `VM Snapshot 11/13/2019, 9:59:56 AM` becomes `VM Snapshot 11%252f13%252f2019, 9:59:56 AM` was causing failures because python could convert to string.

Added tests to use case and updated pack version and change log.