### PR TITLE
Update/add disk controller object to serialize

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.11.1
+
+Added vim.vm.device.VirtualLsiLogicController object to vmwarelib/serialize.py which was
+needed to get the full result from vsphere.vm_hw_scsi_controllers_get
+
+Contributed by John Schoewe (Encore Technologies).
+
 ## v0.11.0
 
 Added new actions:

--- a/actions/vmwarelib/serialize.py
+++ b/actions/vmwarelib/serialize.py
@@ -41,6 +41,7 @@ NON_JSON_SERILIZABLE_TYPES = [
     vim.vm.device.VirtualDevice.PciBusSlotInfo,
     vim.vm.device.VirtualDisk,
     vim.vm.device.VirtualDisk.FlatVer2BackingInfo,
+    vim.vm.device.VirtualLsiLogicController,
     vim.vm.device.VirtualLsiLogicSASController,
     vim.vm.VirtualHardware,
     vmodl.DynamicProperty

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.11.0
+version: 0.11.1
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:


### PR DESCRIPTION
Added SCSI controller object to serialize.py file for vsphere.vm_hw_scsi_controllers_get action. This object should have been included in https://github.com/StackStorm-Exchange/stackstorm-vsphere/pull/66