### PR TITLE
Feature/datastore filters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## v0.13.0
+
+Added new action:
+* `vsphere.get_tags_from_objects` - Retrieves all the tags from an object tags are returned in a dictionary of `category_name: tag_name`
+
+Changed action:
+* `vsphere.vm_bestfit` - Added `datastore_filter_strategy` input that is defaulted to `exclude_matches` which is the current behavior. This gives
+                         the user more flexibility as to how they want to filter the returned datastores.
+
+Contributed by Bradley Bishop (Encore Technologies).
+
 ## v0.12.0
 
 Added new actions:

--- a/README.md
+++ b/README.md
@@ -193,6 +193,42 @@ At line:1 char:1
 
 Changing the script_arguments to another number results in the action failing.
 
+## VM Bestfit
+
+The `vsphere.vm_bestfit` action accepts a VMware Cluster Name an optional datastore filter optional disks array and a defaulted datastore filter strategy. This action uses the information provided to return a Cluster Name, Host information, and Datastore information from VMware that has been checked to make sure the VM can exist.
+
+Before the action returns Host or Datastore information it checks utilizations to recommend the Host or Datastore that is least utilized to make sure the VM will not be put somewhere that does not have capacity. In addition to those checks for Datastores a `datastore_filter_regex_list` and `datastore_filter_strategy` can be included to match the names of Datastores. After the name filtering has happened the utilizations of returned datastores will be checked.
+
+The `datastore_filter_strategy` is defaulted to `exclude_matches` meaning if a `datastore_filter_regex_list` is passed and it matches the name of a datastore then that datastore will be filtered out and not be able to be used for storage.
+
+example:
+```
+datastore_filter_regex_list = ['test1']
+datastores = ['test1', 'test2', 'test3']
+
+returned_usuable_datastores = ['test2', 'test3']
+```
+
+The `datastore_filter_strategy` can be changed to `include_matches` meaning if a `datastore_filter_regex_list` is passed and it does not match the name of a datastore then that datastore will be filtered out and not be able to be used for storage.
+
+example:
+```
+datastore_filter_regex_list = ['test1']
+datastores = ['test1', 'test2', 'test3']
+
+returned_usuable_datastores = ['test1']
+```
+
+In addition to supplying names the action also accepts regex expressions for the filtering.
+
+example (include_matches):
+```
+datastore_filter_regex_list = ["(?i)(iso)"]
+datastores = ['test_isos', 'test1', 'test2', 'test3']
+
+returned_usuable_datastores = ['test_isos']
+```
+
 ## Todo
 
 * Create actions for vsphere environment data retrieval. Allow for integration with external systems for accurate action calls with informed parameter values.
@@ -205,57 +241,78 @@ The version specification is to ensure compatibility with Python 2.7.6 (standard
 PYVMOMI 6.0 requires alternative connection coding and Python 2.7.9 minimum due to elements of the SSL module being used.
 
 ## Actions
-* `vsphere.affinity_rule_create` - Creates an affinity rule for vms to hosts
-* `vsphere.affinity_rule_delete` - Deletes an affinity rule and the groups associated with it
-* `vsphere.custom_attr_assign` - Assign a custom attribute to a given object
-* `vsphere.custom_attr_assign_or_create` - Create a custom attribute if it doesn't exist and asssign it to a given object
-* `vsphere.custom_attr_create` - Create a custom attribute with the given name
-* `vsphere.custom_attr_get` - Return the value of the given Custom Attribute on an object
-* `vsphere.get_moid` - Returns the MOID of vSphere managed entity corresponding to the specified parameters
-* `vsphere.get_objects_with_tag` - Returns a list of objects with a given vmware tag id or name.
-* `vsphere.get_tags_on_object` - Returns a list of vmware tags on a given object.
-* `vsphere.get_vmconsole_urls` - Retrieves urls of the virtual machines' consoles
-* `vsphere.get_vms` - Retrieves the virtual machines on a vCenter Server system. It computes the union of Virtual Machine sets based on each parameter.
-* `vsphere.guest_dir_create` - Create a directory inside the guest.
-* `vsphere.guest_dir_delete` - Delete a directory inside the guest.
-* `vsphere.guest_file_create` - Create a file inside the guest.
-* `vsphere.guest_file_delete` - Delete a file inside the guest.
-* `vsphere.guest_file_read` - Read the contents of a file inside the guest.
-* `vsphere.guest_file_upload` - Upload the contents of a file to the guest.
-* `vsphere.guest_process_start` - Start a process inside the guest.
-* `vsphere.guest_process_wait` - Wait for a process to finish inside the guest.
-* `vsphere.guest_script_run` - Orquesta workflow to upload and run a script inside the guest, and capture results.
-* `vsphere.hello_vsphere` - Wait for a Task to complete and returns its result.
-* `vsphere.host_get` - Retrieves the Summary information for an ESX host.
-* `vsphere.host_network_hints_get` - Retrieves the Network Hints for an ESX host.
-* `vsphere.set_vm` - Changes configuration of a Virtual Machine.
-* `vsphere.tag_id_get` - Retrieves the ID of a tag with the given category and name.
-* `vsphere.tags_attach_by_id` - Attach a list of tags to a given object
-* `vsphere.vm_bestfit` - Determines the best host and datastore to provision a new VM to on a given cluster
-* `vsphere.vm_check_tools` - Wait for a Task to complete and returns its result.
-* `vsphere.vm_config_info_get` - Retrieve config details of a VM object
-* `vsphere.vm_create_from_template` - Create a new VM from existing template.
-* `vsphere.vm_env_items_get` - Retrieve list of Objects from VSphere
-* `vsphere.vm_guest_info_get` - Retrieve Guest details of a VM object
-* `vsphere.vm_hw_barebones_create` - Create BareBones VM (CPU, Ram, Graphics Only)
-* `vsphere.vm_hw_basic_build` - Minstral Flow to Build Basic Server and power it on.
-* `vsphere.vm_hw_cpu_mem_edit` - Adjust the CPU and RAM values assigned to a Virtual Machine
-* `vsphere.vm_hw_detail_get` - Retrieve Vsphere Data about a virtual machine
-* `vsphere.vm_hw_hdd_add` - Add a HardDrive Object to a Virtual Machine
-* `vsphere.vm_hw_hdds_get` - Retrieve a list of HDD information from the given VM
-* `vsphere.vm_hw_moid_get` - Retrieve VM MOID
-* `vsphere.vm_hw_nic_add` - Add a Network Device to VM and attach to designated network.
-* `vsphere.vm_hw_nic_edit` - Edit Network Device on Virtual machine (V0.2 only allows to switch network)
-* `vsphere.vm_hw_power_off` - Perform VM Power off - Equivilant of Holding power button
-* `vsphere.vm_hw_power_on` - Power on Virtual Machine
-* `vsphere.vm_hw_remove` - Removes the Virtual Machine.
-* `vsphere.vm_hw_scsi_controller_add` - Add SCSI HDD Controller device to VM
-* `vsphere.vm_hw_scsi_controllers_get` - Retrieve a list of SCSI controllers on the given VM
-* `vsphere.vm_hw_uuid_get` - Retrieve VM UUID
-* `vsphere.vm_runtime_info_get` - Retrieves the Runtime information for a VM.
-* `vsphere.vm_snapshots_delete`	- Removes any snapshots older than the specified age. Ignores any snapshots with names that match the given regex patterns
-* `vsphere.vm_snapshots_get` - Returns detailed information about the snapshots.
-* `vsphere.wait_task` - Wait for a Task to complete and returns its result.
+|  Action  |  Description  |
+|---|---|
+|  affinity_rule_create  |  Creates an affinity rule for vms to hosts  |
+|  affinity_rule_delete  |  Deletes an affinity rule and the groups associated with it  |
+|  custom_attr_assign  |  Assign a custom attribute to a given object  |
+|  custom_attr_assign_or_create  |  Create a custom attribute if it doesn't exist and asssign it to a given object  |
+|  custom_attr_create  |  Assign a custom attribute to a given object  |
+|  custom_attr_get  |  Return the value of the given Custom Attribute on an object  |
+|  datastore_get  |  Retrieve summary information for given Datastores or All Datastores if none are given  |
+|  get_moid  |  Returns the MOID of vSphere managed entity corresponding to the specified parameters. If the corresponding entities are not found then the action will fail.  |
+|  get_objects_with_tag  |  Retrieves list of objects on a vCenter Server system that have the specified tag id OR name (not both)  |
+|  get_tag_value_from_object  |  Get the value of a tag with a given category and object  |
+|  get_tag_value_from_objects  |  Get the value of a tag with a given category and object  |
+|  get_tags_from_objects  |  Get all tags from objects  |
+|  get_tags_on_object  |  Retrieves list of tags that are present on a given object  |
+|  get_vmconsole_urls  |  Retrieves urls of the virtual machines' consoles  |
+|  get_vms  |  Retrieves the virtual machines on a vCenter Server system. It computes the union of Virtual Machine sets based on each parameter.  |
+|  guest_dir_create  |  Creates a temporary directory inside the guest.  |
+|  guest_dir_delete  |  Deletes a directory inside the guest.  |
+|  guest_file_create  |  Creates a temporary file inside the guest.  |
+|  guest_file_delete  |  Deletes a file inside the guest.  |
+|  guest_file_read  |  Read a file inside the guest.  |
+|  guest_file_upload  |  Upload a file to the guest.  |
+|  guest_process_run  |  Run a process inside the guest.  |
+|  guest_process_start  |  Start a process inside the guest.  |
+|  guest_process_wait  |  Wait for a process inside the guest to exit.  |
+|  guest_script_run  |  Run a script inside the guest.  |
+|  hello_vsphere  |  Wait for a Task to complete and returns its result.  |
+|  host_get  |  Retrieve summary information for given Hosts (ESXi)  |
+|  host_network_hits_get  |  Retrieve Network Hints for given Hosts (ESXi)  |
+|  set_vm  |  Changes configuration of a Virtual Machine.  |
+|  tag_attach_or_create  |  Attach a tag to a given object and create the tag and category if they don't exist  |
+|  tag_category_create  |  Create a vsphere tag category  |
+|  tag_category_delete  |  Delete a tag category from vSphere  |
+|  tag_category_list  |  List all tag categories from vsphere  |
+|  tag_create  |  Create a vsphere tag with the given category  |
+|  tag_delete  |  Delete a tag from vSphere  |
+|  tag_id_get  |  Retrieves the ID of a tag with the given category and name  |
+|  tag_list  |  List all tags from a given category or all tags if no category is given  |
+|  tags_attach_by_id  |  Attach a list of tag IDs to a given object  |
+|  vm_bestfit  |  This action is used to determine the best host and datastore to provision a new VM to on a given cluster
+  |
+|  vm_check_tools  |  Wait for a Task to complete and returns its result.  |
+|  vm_config_info_get  |  Retrieve config details of a VM object  |
+|  vm_create_from_template  |  Create a new VM from existing template.  |
+|  vm_env_items_get  |  Retrieve list of Objects from VSphere  |
+|  vm_folder_get  |  Retrieve the containing folder of a VM object  |
+|  vm_guest_info_get  |  Retrieve Guest details of a VM object  |
+|  vm_hw_barebones_create  |  Create BareBones VM (CPU, Ram, Graphics Only)  |
+|  vm_hw_basic_build  |  WorkFlow to build a base VM hardware and optional power on (CPU, RAM, HDD, NIC)  |
+|  vm_hw_cpu_mem_edit  |  Adjust CPU and RAM allocation for a Virtual Machine  |
+|  vm_hw_detail_get  |  Retrieve details of a VM object  |
+|  vm_hw_hdd_add  |  Add New Hdd to Virtual Machine. You must Provide Either VM_ID or Name.  |
+|  vm_hw_hdds_get  |  Retrieve a list of HDD information from the given VM. You must Provide Either VM_ID or Name.  |
+|  vm_hw_moid_get  |  Retrieve moid of a VM object  |
+|  vm_hw_nic_add  |  Add New Hdd to Virtual Machine. You must Provide Either VM_ID or Name.  |
+|  vm_hw_nic_edit  |  Alter Configuration of Network Adapater  |
+|  vm_hw_power_off  |  Performs a Hardware Power Off of a VM. Note: This is not an OS shutdown.  |
+|  vm_hw_power_on  |  Performs a Hardware Power On of a VM.  |
+|  vm_hw_remove  |  Removes the Virtual Machine.  |
+|  vm_hw_scsi_controller_add  |  Add SCSI Controller to VM. You must provide at least one of VM_ID or Name  |
+|  vm_hw_scsi_controllers_get  |  Retrieve a list of SCSI controllers on the given VM  |
+|  vm_hw_uuid_get  |  Retrieve uuid of a VM object  |
+|  vm_networks_get  |  Retrieve a list of network names that the given VM is on  |
+|  vm_rename  |  Renames the Virtual Machine.  |
+|  vm_resource_pool_get  |  Retrieve the MOID of the of the given VM's containing resource pool  |
+|  vm_runtime_info_get  |  Retrieve Runtime details of a VM object  |
+|  vm_shutdown  |  Initiates a clean shutdown of the guest.  Returns immediately without waiting for the guest to complete shutdown.  |
+|  vm_snapshots_delete  |  Removes any snapshots older than the specified age. Ignores any snapshots with names that match the given rexex patterns  |
+|  vm_snapshots_get  |  Return the list of snapshots  |
+|  vm_tools_options_update  |  Changes configuration of a Virtual Machine tools options.  |
+|  wait_task  |  Wait for a Task to complete and returns its result.  |
 
 ## Known Bugs
 * Bug: `vm_hw_hdd_add`, Specifying datastore does not work. New files will be added to the same datastore as the core VM files. Note: Specifying a Datastore Cluster does still install files to the correct set of datastores.

--- a/README.md
+++ b/README.md
@@ -281,8 +281,7 @@ PYVMOMI 6.0 requires alternative connection coding and Python 2.7.9 minimum due 
 |  tag_id_get  |  Retrieves the ID of a tag with the given category and name  |
 |  tag_list  |  List all tags from a given category or all tags if no category is given  |
 |  tags_attach_by_id  |  Attach a list of tag IDs to a given object  |
-|  vm_bestfit  |  This action is used to determine the best host and datastore to provision a new VM to on a given cluster
-  |
+|  vm_bestfit  |  This action is used to determine the best host and datastore to provision a new VM to on a given cluster  |
 |  vm_check_tools  |  Wait for a Task to complete and returns its result.  |
 |  vm_config_info_get  |  Retrieve config details of a VM object  |
 |  vm_create_from_template  |  Create a new VM from existing template.  |

--- a/actions/get_tags_from_objects.py
+++ b/actions/get_tags_from_objects.py
@@ -1,0 +1,50 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.actions import BaseAction
+
+
+class GetTagsFromObjects(BaseAction):
+    def get_tags(self, object_id, object_type):
+        obj_tags = self.tagging.tag_association_list_attached_tags(object_type, object_id)
+        tags = {}
+        for obj in obj_tags:
+            tag = self.tagging.tag_get(obj)
+            category = self.tagging.category_get(tag['category_id'])
+            tags[category['name']] = tag['name']
+
+        # dictionary of category name: tag name
+        return tags
+
+    def run(self, object_ids, object_type, vsphere=None):
+        """
+        Connect to the REST API return a list of tag values for the given object and category
+
+        Args:
+          - kwargs: inputs to the aciton
+          - category_name: Category of the tag to create
+          - object_id: VMWare Object ID to get tags from (vm-1234)
+          - object_type: Object type that corresponds to the ID (VirtualMachine)
+          - vsphere: Pre-configured vsphere connection details (config.yaml)
+
+        Returns:
+        - Dictionary: List of tag values for the given object and category
+        """
+        self.connect_rest(vsphere)
+
+        result = {}
+        for object_id in object_ids:
+            result[object_id] = self.get_tags(object_id, object_type)
+
+        return result

--- a/actions/get_tags_from_objects.yaml
+++ b/actions/get_tags_from_objects.yaml
@@ -1,0 +1,23 @@
+---
+name: get_tags_from_objects
+runner_type: python-script
+description: Get all tags from objects
+enabled: true
+entry_point: get_tags_from_objects.py
+parameters:
+  object_ids:
+    type: array
+    description: ID of the objects to return tags from
+    required: true
+    position: 0
+  object_type:
+    type: string
+    description: Type of he object to return tags from (e.g. VirtualMachine)
+    required: true
+    position: 1
+  vsphere:
+    type: string
+    description: Pre-Configured vsphere connection details
+    required: false
+    default: ~
+    position: 2

--- a/actions/vm_bestfit.yaml
+++ b/actions/vm_bestfit.yaml
@@ -10,6 +10,13 @@ parameters:
         type: string
         description: Name of the cluster in vSphere
         required: true
+    datastore_filter_strategy:
+        type: string
+        description:
+        required: "exclude_matches"
+        enum:
+          - 'exclude_matches'
+          - 'include_matches'
     datastore_filter_regex_list:
         type: array
         items:

--- a/actions/vm_bestfit.yaml
+++ b/actions/vm_bestfit.yaml
@@ -12,8 +12,8 @@ parameters:
         required: true
     datastore_filter_strategy:
         type: string
-        description:
-        required: "exclude_matches"
+        description: Filter strategy for if you want to exclude or include the datastore matches found.
+        default: "exclude_matches"
         enum:
           - 'exclude_matches'
           - 'include_matches'

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.12.0
+version: 0.13.0
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/test_action_get_tags_from_objects.py
+++ b/tests/test_action_get_tags_from_objects.py
@@ -1,0 +1,141 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+
+from get_tags_from_objects import GetTagsFromObjects
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'GetTagsFromObjectsTestCase'
+]
+
+
+class GetTagsFromObjectsTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = GetTagsFromObjects
+
+    def test_get_tags(self):
+        action = self.get_action_instance(self.new_config)
+
+        # define test variables
+        object_type = "VirtualMachine"
+        object_id = "vm-123"
+
+        # mock
+        action.tagging = mock.MagicMock()
+        action.tagging.tag_association_list_attached_tags.return_value = ["345", "111", "987"]
+        action.tagging.tag_get.side_effect = [
+            {
+                'tag_id': "987",
+                'name': 'test_tag_1',
+                'category_id': '123'
+            }, {
+                'tag_id': "012",
+                'name': 'test_tag_2',
+                'category_id': '456'
+            }, {
+                'tag_id': "385",
+                'name': 'test_tag_3',
+                'category_id': '678'
+            }
+        ]
+        action.tagging.category_get.side_effect = [
+            {
+                'category_id': "123",
+                'name': 'test_category_1',
+            }, {
+                'category_id': "456",
+                'name': 'test_category_2',
+            }, {
+                'category_id': "678",
+                'name': 'test_category_3',
+            }
+        ]
+
+        expected_result = {
+            'test_category_1': 'test_tag_1',
+            'test_category_2': 'test_tag_2',
+            'test_category_3': 'test_tag_3',
+        }
+
+        # invoke action with valid parameters
+        result = action.get_tags(object_id, object_type)
+
+        self.assertEqual(result, expected_result)
+        action.tagging.tag_association_list_attached_tags.assert_called_with(
+            object_type, object_id)
+
+    @mock.patch("vmwarelib.actions.BaseAction.connect_rest")
+    def test_run(self, mock_connect):
+        action = self.get_action_instance(self.new_config)
+
+        # define test variables
+        object_type = "VirtualMachine"
+        object_ids = ["vm-123"]
+        vsphere = "default"
+        test_kwargs = {
+            "object_type": object_type,
+            "object_ids": object_ids,
+            "vsphere": vsphere
+        }
+
+        # mock
+        action.tagging = mock.MagicMock()
+        action.tagging.tag_association_list_attached_tags.return_value = ["345", "111", "987"]
+        action.tagging.tag_get.side_effect = [
+            {
+                'tag_id': "987",
+                'name': 'test_tag_1',
+                'category_id': '123'
+            }, {
+                'tag_id': "012",
+                'name': 'test_tag_2',
+                'category_id': '456'
+            }, {
+                'tag_id': "385",
+                'name': 'test_tag_3',
+                'category_id': '678'
+            }
+        ]
+        action.tagging.category_get.side_effect = [
+            {
+                'category_id': "123",
+                'name': 'test_category_1',
+            }, {
+                'category_id': "456",
+                'name': 'test_category_2',
+            }, {
+                'category_id': "678",
+                'name': 'test_category_3',
+            }
+        ]
+
+        expected_result = {
+            'vm-123': {
+                'test_category_1': 'test_tag_1',
+                'test_category_2': 'test_tag_2',
+                'test_category_3': 'test_tag_3',
+            }
+        }
+
+        # invoke action with valid parameters
+        result = action.run(**test_kwargs)
+
+        self.assertEqual(result, expected_result)
+
+        action.tagging.tag_association_list_attached_tags.assert_called_with(
+            object_type, object_ids[0])
+
+        mock_connect.assert_called_with(vsphere)


### PR DESCRIPTION
* `vsphere.get_tags_from_objects` - Retrieves all the tags from an object tags are returned in a dictionary of `category_name: tag_name`

Changed action:
* `vsphere.vm_bestfit` - Added `datastore_filter_strategy` input that is defaulted to `exclude_matches` which is the current behavior. This gives
                         the user more flexibility as to how they want to filter the returned datastores.