### PR TITLE
Feature/networks get

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## v0.14.0
+
+Added new action:
+* `vsphere.network_get` - Retrieve a list of networks with summary information and an ID from vCenter
+
+Changed action:
+* `vsphere.datastore_get` - Updated the action to include the ID of the datastore in the return.
+* `vsphere.affinity_rule_create` - Updated the action to return the name of the hosts that were included in the rule.
+
+Contributed by Bradley Bishop (Encore Technologies).
+
 ## v0.13.1
 * Force release to get latest tags on repo
 

--- a/actions/affinity_rule_create.py
+++ b/actions/affinity_rule_create.py
@@ -61,7 +61,11 @@ class AffinityRuleCreate(BaseAction):
         # Run Reconfigure task
         task_return = self._wait_for_task(cluster.ReconfigureEx(config_spec, modify=True))
 
-        return task_return
+        host_name_return = []
+        for host in hosts:
+            host_name_return.append(host.name)
+
+        return (task_return, {'host_names': host_name_return})
 
     def create_group(self, rule_name, object_array, group_type):
         """ Creates a group to be created in VMware. Returns the group

--- a/actions/datastore_get.py
+++ b/actions/datastore_get.py
@@ -22,9 +22,11 @@ import json
 
 class DatastoreGet(BaseAction):
     def get_datastore_dict(self, datastore):
+        summary = json.loads(json.dumps(datastore.summary, cls=DatastoreGetJSONEncoder))
         return_dict = {
             'name': datastore.name,
-            'summary': json.loads(json.dumps(datastore.summary, cls=DatastoreGetJSONEncoder))
+            'id': summary['datastore']['_moId'],
+            'summary': summary
         }
 
         return return_dict

--- a/actions/network_get.py
+++ b/actions/network_get.py
@@ -1,0 +1,83 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib import inventory
+from vmwarelib.serialize import NetworkGetJSONEncoder
+from vmwarelib.actions import BaseAction
+from pyVmomi import vim  # pylint: disable-msg=E0611
+import json
+
+
+class NetworkGet(BaseAction):
+    def get_network_dict(self, network):
+        is_dvs = False
+        if isinstance(network, vim.dvs.DistributedVirtualPortgroup):
+            is_dvs = True
+
+        summary = json.loads(json.dumps(network.summary, cls=NetworkGetJSONEncoder))
+        return_dict = {
+            'name': network.name,
+            'id': summary['network']['_moId'],
+            'is_dvs': is_dvs,
+            'summary': summary
+        }
+
+        return return_dict
+
+    def get_all(self):
+        results = []
+        networks = inventory.get_managed_entities(self.si_content, vim.Network)
+        for network in networks.view:
+            results.append(self.get_network_dict(network))
+
+        return results
+
+    def get_by_id_or_name(self, network_ids=[], network_names=[]):
+        results = []
+
+        for did in network_ids:
+            network = inventory.get_network(self.si_content, moid=did)
+            if network and network.name not in results:
+                results.append(self.get_network_dict(network))
+
+        for network in network_names:
+            network = inventory.get_network(self.si_content, name=network)
+            if network and network.name not in results:
+                results.append(self.get_network_dict(network))
+
+        return results
+
+    def run(self, network_ids, network_names, vsphere=None):
+        """
+        Retrieve summary information for given networks (ESXi)
+
+        Args:
+        - network_ids: Moid of network to retrieve
+        - network_names: Name of network to retrieve
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+
+        Returns:
+        - array: network objects
+        """
+        return_results = []
+
+        self.establish_connection(vsphere)
+
+        if not network_ids and not network_names:
+            return_results = self.get_all()
+        else:
+            return_results = self.get_by_id_or_name(network_ids, network_names)
+
+        return return_results

--- a/actions/network_get.yaml
+++ b/actions/network_get.yaml
@@ -1,0 +1,23 @@
+---
+name: network_get
+pack: vsphere
+runner_type: python-script
+description: Retrieve summary information for given Networks or All Networks if none are given
+entry_point: network_get.py
+parameters:
+  network_ids:
+    type: array
+    description: Comma seperated list of network IDs
+    required: false
+    position: 0
+  network_names:
+    type: array
+    description: Comma seperated list of network Names
+    required: false
+    position: 1
+    default: ~
+  vsphere:
+    type: string
+    description: Pre-configured vsphere endpoint
+    required: false
+    position: 2

--- a/actions/vmwarelib/serialize.py
+++ b/actions/vmwarelib/serialize.py
@@ -85,6 +85,12 @@ DATASTORE_GET_NON_JSON_SERILIZABLE_TYPES = [
     vim.Datastore.Summary
 ]
 
+NETWORK_GET_NON_JSON_SERILIZABLE_TYPES = [
+    vim.Network,
+    vim.Network.Summary,
+    vim.dvs.DistributedVirtualPortgroup
+]
+
 
 class MyJSONEncoder(json.JSONEncoder):
     def default(self, obj):  # pylint: disable=E0202
@@ -116,6 +122,18 @@ class DatastoreGetJSONEncoder(json.JSONEncoder):
             return super(DatastoreGetJSONEncoder, self).default(obj)
         except TypeError:
             if type(obj) in DATASTORE_GET_NON_JSON_SERILIZABLE_TYPES:
+                return obj.__dict__
+
+            # For anything else just return the class name
+            return "__{}__".format(obj.__class__.__name__)
+
+
+class NetworkGetJSONEncoder(json.JSONEncoder):
+    def default(self, obj):  # pylint: disable=E0202
+        try:
+            return super(NetworkGetJSONEncoder, self).default(obj)
+        except TypeError:
+            if type(obj) in NETWORK_GET_NON_JSON_SERILIZABLE_TYPES:
                 return obj.__dict__
 
             # For anything else just return the class name

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.13.1
+version: 0.14.0
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/test_action_affinity_rule_create.py
+++ b/tests/test_action_affinity_rule_create.py
@@ -146,11 +146,16 @@ class AffinityRuleCreateTestCase(VsphereBaseActionTestCase):
         mock_cluster.ReconfigureEx.return_value = "Cluster Reconfigure Return"
         cluster_name_property = mock.PropertyMock(return_value=test_dict['cluster_name'])
         type(mock_cluster).name = cluster_name_property
+
         mock_host = mock.Mock()
+        host_name_property = mock.PropertyMock(return_value="test_host")
+        type(mock_host).name = host_name_property
+
         mock_vm = mock.Mock()
-        mock_vm.runtime.host.return_value = mock_host
+        mock_vm.runtime.host = mock_host
         vm_name_property = mock.PropertyMock(return_value=test_dict['vm_names'][0])
         type(mock_vm).name = vm_name_property
+
         mock_view = mock.Mock(view=[mock_vm, mock_cluster])
         mock_vmware = mock.Mock(rootFolder="folder")
         mock_vmware.viewManager.CreateContainerView.return_value = mock_view
@@ -160,4 +165,4 @@ class AffinityRuleCreateTestCase(VsphereBaseActionTestCase):
         mock__wait_for_task.return_value = True
 
         result_value = self._action.run(**test_dict)
-        self.assertEqual(result_value, True)
+        self.assertEqual(result_value, (True, {'host_names': ["test_host"]}))

--- a/tests/test_action_datastore_get.py
+++ b/tests/test_action_datastore_get.py
@@ -40,12 +40,18 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         datastore_1 = mock.Mock()
         datastore_1_name_property = mock.PropertyMock(return_value='test_datastore')
         type(datastore_1).name = datastore_1_name_property
-        datastore_1.summary = 'expected_summary'
+        expected_sumary = {
+            'datastore': {
+                '_moId': 1
+            }
+        }
+        datastore_1.summary = expected_sumary
         datastore_1._moId = 1
 
         expected_result = {
             'name': 'test_datastore',
-            'summary': 'expected_summary'
+            'id': 1,
+            'summary': expected_sumary
         }
 
         result = self._action.get_datastore_dict(datastore_1)
@@ -55,31 +61,56 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         datastore_1 = mock.Mock()
         datastore_1_name_property = mock.PropertyMock(return_value='test_datastore')
         type(datastore_1).name = datastore_1_name_property
-        datastore_1.summary = 'expected_summary'
+        expected_sumary_1 = {
+            'datastore': {
+                '_moId': 1
+            }
+        }
+        datastore_1.summary = expected_sumary_1
         datastore_1._moId = 1
 
         datastore_2 = mock.Mock()
         datastore_2_name_property = mock.PropertyMock(return_value='test_datastore_2')
         type(datastore_2).name = datastore_2_name_property
-        datastore_2.summary = 'expected_summary_2'
+        expected_sumary_2 = {
+            'datastore': {
+                '_moId': 2
+            }
+        }
+        datastore_2.summary = expected_sumary_2
         datastore_2._moId = 2
 
         datastore_3 = mock.Mock()
         datastore_3_name_property = mock.PropertyMock(return_value='test_datastore_3')
         type(datastore_3).name = datastore_3_name_property
-        datastore_3.summary = 'expected_summary_3'
+        expected_sumary_3 = {
+            'datastore': {
+                '_moId': 3
+            }
+        }
+        datastore_3.summary = expected_sumary_3
         datastore_3._moId = 3
 
         datastore_4 = mock.Mock()
         datastore_4_name_property = mock.PropertyMock(return_value='test_datastore_4')
         type(datastore_4).name = datastore_4_name_property
-        datastore_4.summary = 'expected_summary_4'
+        expected_sumary_4 = {
+            'datastore': {
+                '_moId': 4
+            }
+        }
+        datastore_4.summary = expected_sumary_4
         datastore_4._moId = 4
 
         datastore_5 = mock.Mock()
         datastore_5_name_property = mock.PropertyMock(return_value='test_datastore_5')
         type(datastore_5).name = datastore_5_name_property
-        datastore_5.summary = 'expected_summary_5'
+        expected_sumary_5 = {
+            'datastore': {
+                '_moId': 5
+            }
+        }
+        datastore_5.summary = expected_sumary_5
         datastore_5._moId = 5
 
         mock_view = mock.Mock(view=[datastore_1,
@@ -94,13 +125,16 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         expected_result = [
             {
                 'name': 'test_datastore_4',
-                'summary': 'expected_summary_4'
+                'id': 4,
+                'summary': expected_sumary_4
             }, {
                 'name': 'test_datastore_2',
-                'summary': 'expected_summary_2'
+                'id': 2,
+                'summary': expected_sumary_2
             }, {
                 'name': 'test_datastore_5',
-                'summary': 'expected_summary_5'
+                'id': 5,
+                'summary': expected_sumary_5
             }
         ]
 
@@ -111,12 +145,24 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         datastore_1 = mock.Mock()
         datastore_1_name_property = mock.PropertyMock(return_value='test_datastore')
         type(datastore_1).name = datastore_1_name_property
-        datastore_1.summary = 'expected_summary'
+        expected_sumary_1 = {
+            'datastore': {
+                '_moId': 1
+            }
+        }
+        datastore_1.summary = expected_sumary_1
+        datastore_1._moId = 1
 
         datastore_2 = mock.Mock()
         datastore_2_name_property = mock.PropertyMock(return_value='test_datastore_2')
         type(datastore_2).name = datastore_2_name_property
-        datastore_2.summary = 'expected_summary_2'
+        expected_sumary_2 = {
+            'datastore': {
+                '_moId': 2
+            }
+        }
+        datastore_2.summary = expected_sumary_2
+        datastore_2._moId = 2
 
         mock_view = mock.Mock(view=[datastore_1, datastore_2])
         mock_vmware = mock.Mock(rootFolder="folder")
@@ -126,10 +172,12 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         expected_result = [
             {
                 'name': 'test_datastore',
-                'summary': 'expected_summary'
+                'id': 1,
+                'summary': expected_sumary_1
             }, {
                 'name': 'test_datastore_2',
-                'summary': 'expected_summary_2'
+                'id': 2,
+                'summary': expected_sumary_2
             }
         ]
 
@@ -140,31 +188,56 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         datastore_1 = mock.Mock()
         datastore_1_name_property = mock.PropertyMock(return_value='test_datastore')
         type(datastore_1).name = datastore_1_name_property
-        datastore_1.summary = 'expected_summary'
+        expected_sumary_1 = {
+            'datastore': {
+                '_moId': 1
+            }
+        }
+        datastore_1.summary = expected_sumary_1
         datastore_1._moId = 1
 
         datastore_2 = mock.Mock()
         datastore_2_name_property = mock.PropertyMock(return_value='test_datastore_2')
         type(datastore_2).name = datastore_2_name_property
-        datastore_2.summary = 'expected_summary_2'
+        expected_sumary_2 = {
+            'datastore': {
+                '_moId': 2
+            }
+        }
+        datastore_2.summary = expected_sumary_2
         datastore_2._moId = 2
 
         datastore_3 = mock.Mock()
         datastore_3_name_property = mock.PropertyMock(return_value='test_datastore_3')
         type(datastore_3).name = datastore_3_name_property
-        datastore_3.summary = 'expected_summary_3'
+        expected_sumary_3 = {
+            'datastore': {
+                '_moId': 3
+            }
+        }
+        datastore_3.summary = expected_sumary_3
         datastore_3._moId = 3
 
         datastore_4 = mock.Mock()
         datastore_4_name_property = mock.PropertyMock(return_value='test_datastore_4')
         type(datastore_4).name = datastore_4_name_property
-        datastore_4.summary = 'expected_summary_4'
+        expected_sumary_4 = {
+            'datastore': {
+                '_moId': 4
+            }
+        }
+        datastore_4.summary = expected_sumary_4
         datastore_4._moId = 4
 
         datastore_5 = mock.Mock()
         datastore_5_name_property = mock.PropertyMock(return_value='test_datastore_5')
         type(datastore_5).name = datastore_5_name_property
-        datastore_5.summary = 'expected_summary_5'
+        expected_sumary_5 = {
+            'datastore': {
+                '_moId': 5
+            }
+        }
+        datastore_5.summary = expected_sumary_5
         datastore_5._moId = 5
 
         mock_view = mock.Mock(view=[datastore_1,
@@ -179,13 +252,16 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         expected_result = [
             {
                 'name': 'test_datastore_4',
-                'summary': 'expected_summary_4'
+                'id': 4,
+                'summary': expected_sumary_4
             }, {
                 'name': 'test_datastore_2',
-                'summary': 'expected_summary_2'
+                'id': 2,
+                'summary': expected_sumary_2
             }, {
                 'name': 'test_datastore_5',
-                'summary': 'expected_summary_5'
+                'id': 5,
+                'summary': expected_sumary_5
             }
         ]
 
@@ -196,31 +272,56 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         datastore_1 = mock.Mock()
         datastore_1_name_property = mock.PropertyMock(return_value='test_datastore')
         type(datastore_1).name = datastore_1_name_property
-        datastore_1.summary = 'expected_summary'
+        expected_sumary_1 = {
+            'datastore': {
+                '_moId': 1
+            }
+        }
+        datastore_1.summary = expected_sumary_1
         datastore_1._moId = 1
 
         datastore_2 = mock.Mock()
         datastore_2_name_property = mock.PropertyMock(return_value='test_datastore_2')
         type(datastore_2).name = datastore_2_name_property
-        datastore_2.summary = 'expected_summary_2'
+        expected_sumary_2 = {
+            'datastore': {
+                '_moId': 2
+            }
+        }
+        datastore_2.summary = expected_sumary_2
         datastore_2._moId = 2
 
         datastore_3 = mock.Mock()
         datastore_3_name_property = mock.PropertyMock(return_value='test_datastore_3')
         type(datastore_3).name = datastore_3_name_property
-        datastore_3.summary = 'expected_summary_3'
+        expected_sumary_3 = {
+            'datastore': {
+                '_moId': 3
+            }
+        }
+        datastore_3.summary = expected_sumary_3
         datastore_3._moId = 3
 
         datastore_4 = mock.Mock()
         datastore_4_name_property = mock.PropertyMock(return_value='test_datastore_4')
         type(datastore_4).name = datastore_4_name_property
-        datastore_4.summary = 'expected_summary_4'
+        expected_sumary_4 = {
+            'datastore': {
+                '_moId': 4
+            }
+        }
+        datastore_4.summary = expected_sumary_4
         datastore_4._moId = 4
 
         datastore_5 = mock.Mock()
         datastore_5_name_property = mock.PropertyMock(return_value='test_datastore_5')
         type(datastore_5).name = datastore_5_name_property
-        datastore_5.summary = 'expected_summary_5'
+        expected_sumary_5 = {
+            'datastore': {
+                '_moId': 5
+            }
+        }
+        datastore_5.summary = expected_sumary_5
         datastore_5._moId = 5
 
         mock_view = mock.Mock(view=[datastore_1,
@@ -235,19 +336,24 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
         expected_result = [
             {
                 'name': 'test_datastore',
-                'summary': 'expected_summary'
+                'id': 1,
+                'summary': expected_sumary_1
             }, {
                 'name': 'test_datastore_2',
-                'summary': 'expected_summary_2'
+                'id': 2,
+                'summary': expected_sumary_2
             }, {
                 'name': 'test_datastore_3',
-                'summary': 'expected_summary_3'
+                'id': 3,
+                'summary': expected_sumary_3
             }, {
                 'name': 'test_datastore_4',
-                'summary': 'expected_summary_4'
+                'id': 4,
+                'summary': expected_sumary_4
             }, {
                 'name': 'test_datastore_5',
-                'summary': 'expected_summary_5'
+                'id': 5,
+                'summary': expected_sumary_5
             }
         ]
 

--- a/tests/test_action_network_get.py
+++ b/tests/test_action_network_get.py
@@ -1,0 +1,376 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+from pyVmomi import vim  # pylint: disable-msg=E0611
+
+# from vmwarelib import inventory
+from network_get import NetworkGet
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'NetworkGet'
+]
+
+
+class NetworkGetTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = NetworkGet
+
+    def setUp(self):
+        super(NetworkGetTestCase, self).setUp()
+
+        self._action = self.get_action_instance(self.new_config)
+
+        self._action.establish_connection = mock.Mock()
+        self._action.si_content = mock.Mock()
+
+    def test_get_network_dict(self):
+        network_1 = mock.Mock()
+        network_1_name_property = mock.PropertyMock(return_value='test_network')
+        type(network_1).name = network_1_name_property
+        expected_sumary = {
+            'network': {
+                '_moId': 1
+            }
+        }
+        network_1.summary = expected_sumary
+        network_1._moId = 1
+
+        expected_result = {
+            'name': 'test_network',
+            'id': 1,
+            'is_dvs': False,
+            'summary': expected_sumary
+        }
+
+        result = self._action.get_network_dict(network_1)
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name(self):
+        network_1 = mock.Mock()
+        network_1_name_property = mock.PropertyMock(return_value='test_network')
+        type(network_1).name = network_1_name_property
+        expected_sumary_1 = {
+            'network': {
+                '_moId': 1
+            }
+        }
+        network_1.summary = expected_sumary_1
+        network_1._moId = 1
+
+        network_2 = mock.Mock()
+        network_2_name_property = mock.PropertyMock(return_value='test_network_2')
+        type(network_2).name = network_2_name_property
+        expected_sumary_2 = {
+            'network': {
+                '_moId': 2
+            }
+        }
+        network_2.summary = expected_sumary_2
+        network_2._moId = 2
+
+        network_3 = mock.Mock(spec=vim.dvs.DistributedVirtualPortgroup)
+        network_3_name_property = mock.PropertyMock(return_value='test_network_3')
+        type(network_3).name = network_3_name_property
+        expected_sumary_3 = {
+            'network': {
+                '_moId': 3
+            }
+        }
+        network_3.summary = expected_sumary_3
+        network_3._moId = 3
+
+        network_4 = mock.Mock()
+        network_4_name_property = mock.PropertyMock(return_value='test_network_4')
+        type(network_4).name = network_4_name_property
+        expected_sumary_4 = {
+            'network': {
+                '_moId': 4
+            }
+        }
+        network_4.summary = expected_sumary_4
+        network_4._moId = 4
+
+        network_5 = mock.Mock(spec=vim.dvs.DistributedVirtualPortgroup)
+        network_5_name_property = mock.PropertyMock(return_value='test_network_5')
+        type(network_5).name = network_5_name_property
+        expected_sumary_5 = {
+            'network': {
+                '_moId': 5
+            }
+        }
+        network_5.summary = expected_sumary_5
+        network_5._moId = 5
+
+        mock_view = mock.Mock(view=[network_1,
+                                    network_2,
+                                    network_3,
+                                    network_4,
+                                    network_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_network_4',
+                'id': 4,
+                'is_dvs': False,
+                'summary': expected_sumary_4
+            }, {
+                'name': 'test_network_2',
+                'id': 2,
+                'is_dvs': False,
+                'summary': expected_sumary_2
+            }, {
+                'name': 'test_network_5',
+                'id': 5,
+                'is_dvs': True,
+                'summary': expected_sumary_5
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([4], ['test_network_2', 'test_network_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_all_networks(self):
+        network_1 = mock.Mock()
+        network_1_name_property = mock.PropertyMock(return_value='test_network')
+        type(network_1).name = network_1_name_property
+        expected_sumary_1 = {
+            'network': {
+                '_moId': 1
+            }
+        }
+        network_1.summary = expected_sumary_1
+        network_1._moId = 1
+
+        network_2 = mock.Mock(spec=vim.dvs.DistributedVirtualPortgroup)
+        network_2_name_property = mock.PropertyMock(return_value='test_network_2')
+        type(network_2).name = network_2_name_property
+        expected_sumary_2 = {
+            'network': {
+                '_moId': 2
+            }
+        }
+        network_2.summary = expected_sumary_2
+        network_2._moId = 2
+
+        mock_view = mock.Mock(view=[network_1, network_2])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_network',
+                'id': 1,
+                'is_dvs': False,
+                'summary': expected_sumary_1
+            }, {
+                'name': 'test_network_2',
+                'id': 2,
+                'is_dvs': True,
+                'summary': expected_sumary_2
+            }
+        ]
+
+        result = self._action.get_all()
+        self.assertEqual(result, expected_result)
+
+    def test_run_get_by_id_or_name(self):
+        network_1 = mock.Mock()
+        network_1_name_property = mock.PropertyMock(return_value='test_network')
+        type(network_1).name = network_1_name_property
+        expected_sumary_1 = {
+            'network': {
+                '_moId': 1
+            }
+        }
+        network_1.summary = expected_sumary_1
+        network_1._moId = 1
+
+        network_2 = mock.Mock()
+        network_2_name_property = mock.PropertyMock(return_value='test_network_2')
+        type(network_2).name = network_2_name_property
+        expected_sumary_2 = {
+            'network': {
+                '_moId': 2
+            }
+        }
+        network_2.summary = expected_sumary_2
+        network_2._moId = 2
+
+        network_3 = mock.Mock(spec=vim.dvs.DistributedVirtualPortgroup)
+        network_3_name_property = mock.PropertyMock(return_value='test_network_3')
+        type(network_3).name = network_3_name_property
+        expected_sumary_3 = {
+            'network': {
+                '_moId': 3
+            }
+        }
+        network_3.summary = expected_sumary_3
+        network_3._moId = 3
+
+        network_4 = mock.Mock()
+        network_4_name_property = mock.PropertyMock(return_value='test_network_4')
+        type(network_4).name = network_4_name_property
+        expected_sumary_4 = {
+            'network': {
+                '_moId': 4
+            }
+        }
+        network_4.summary = expected_sumary_4
+        network_4._moId = 4
+
+        network_5 = mock.Mock()
+        network_5_name_property = mock.PropertyMock(return_value='test_network_5')
+        type(network_5).name = network_5_name_property
+        expected_sumary_5 = {
+            'network': {
+                '_moId': 5
+            }
+        }
+        network_5.summary = expected_sumary_5
+        network_5._moId = 5
+
+        mock_view = mock.Mock(view=[network_1,
+                                    network_2,
+                                    network_3,
+                                    network_4,
+                                    network_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_network_4',
+                'id': 4,
+                'is_dvs': False,
+                'summary': expected_sumary_4
+            }, {
+                'name': 'test_network_2',
+                'id': 2,
+                'is_dvs': False,
+                'summary': expected_sumary_2
+            }, {
+                'name': 'test_network_5',
+                'id': 5,
+                'is_dvs': False,
+                'summary': expected_sumary_5
+            }
+        ]
+
+        result = self._action.run([4], ['test_network_2', 'test_network_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_run_all(self):
+        network_1 = mock.Mock(spec=vim.dvs.DistributedVirtualPortgroup)
+        network_1_name_property = mock.PropertyMock(return_value='test_network')
+        type(network_1).name = network_1_name_property
+        expected_sumary_1 = {
+            'network': {
+                '_moId': 1
+            }
+        }
+        network_1.summary = expected_sumary_1
+        network_1._moId = 1
+
+        network_2 = mock.Mock()
+        network_2_name_property = mock.PropertyMock(return_value='test_network_2')
+        type(network_2).name = network_2_name_property
+        expected_sumary_2 = {
+            'network': {
+                '_moId': 2
+            }
+        }
+        network_2.summary = expected_sumary_2
+        network_2._moId = 2
+
+        network_3 = mock.Mock(spec=vim.dvs.DistributedVirtualPortgroup)
+        network_3_name_property = mock.PropertyMock(return_value='test_network_3')
+        type(network_3).name = network_3_name_property
+        expected_sumary_3 = {
+            'network': {
+                '_moId': 3
+            }
+        }
+        network_3.summary = expected_sumary_3
+        network_3._moId = 3
+
+        network_4 = mock.Mock()
+        network_4_name_property = mock.PropertyMock(return_value='test_network_4')
+        type(network_4).name = network_4_name_property
+        expected_sumary_4 = {
+            'network': {
+                '_moId': 4
+            }
+        }
+        network_4.summary = expected_sumary_4
+        network_4._moId = 4
+
+        network_5 = mock.Mock(spec=vim.dvs.DistributedVirtualPortgroup)
+        network_5_name_property = mock.PropertyMock(return_value='test_network_5')
+        type(network_5).name = network_5_name_property
+        expected_sumary_5 = {
+            'network': {
+                '_moId': 5
+            }
+        }
+        network_5.summary = expected_sumary_5
+        network_5._moId = 5
+
+        mock_view = mock.Mock(view=[network_1,
+                                    network_2,
+                                    network_3,
+                                    network_4,
+                                    network_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_network',
+                'id': 1,
+                'is_dvs': True,
+                'summary': expected_sumary_1
+            }, {
+                'name': 'test_network_2',
+                'id': 2,
+                'is_dvs': False,
+                'summary': expected_sumary_2
+            }, {
+                'name': 'test_network_3',
+                'id': 3,
+                'is_dvs': True,
+                'summary': expected_sumary_3
+            }, {
+                'name': 'test_network_4',
+                'id': 4,
+                'is_dvs': False,
+                'summary': expected_sumary_4
+            }, {
+                'name': 'test_network_5',
+                'id': 5,
+                'is_dvs': True,
+                'summary': expected_sumary_5
+            }
+        ]
+
+        result = self._action.run(None, None)
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
Added new action:
* `vsphere.network_get` - Retrieve a list of networks with summary information and an ID from vCenter

Changed action:
* `vsphere.datastore_get` - Updated the action to include the ID of the datastore in the return.
* `vsphere.affinity_rule_create` - Updated the action to return the name of the hosts that were included in the rule.

Added new tests and updated existing tests for changes to actions.