### PR TITLE
Cluster, Datacenter, Template object get

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,9 @@ Added new action:
 * `vsphere.template_get` - Retrieve a list of templates with summary information and an ID from vCenter
 
 Changed action:
-* `vsphere.datastore_get` - Fixed action to allow passing ids or names and still work properly.
-* `vsphere.network_get` - Fixed action to allow passing ids or names and still work properly.
-* `vsphere.get_tags_from_objects` - Fixed action to handle tag categories that can have multiple values.
+* `vsphere.datastore_get` - Fixed action to allow passing ids or names and still work properly. Fixed duplicate check so its working now and the same item is not added twice to the list when specifing name or id.
+* `vsphere.network_get` - Fixed action to allow passing ids or names and still work properly. Fixed duplicate check so its working now and the same item is not added twice to the list when specifing name or id.
+* `vsphere.get_tags_from_objects` - Fixed action to handle tag categories that can have multiple values. Fixed duplicate check so its working now and the same item is not added twice to the list when specifing name or id.
 
 Contributed by Bradley Bishop (Encore Technologies).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## v0.15.0
+
+Added new action:
+* `vsphere.cluster_get` - Retrieve a list of clusters with summary information and an ID from vCenter
+* `vsphere.datacenter_get` - Retrieve a list of datacenters with configuration information and an ID from vCenter
+* `vsphere.template_get` - Retrieve a list of templates with summary information and an ID from vCenter
+
+Changed action:
+* `vsphere.datastore_get` - Fixed action to allow passing ids or names and still work properly.
+* `vsphere.network_get` - Fixed action to allow passing ids or names and still work properly.
+* `vsphere.get_tags_from_objects` - Fixed action to handle tag categories that can have multiple values.
+
+Contributed by Bradley Bishop (Encore Technologies).
+
 ## v0.14.0
 
 Added new action:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Changed action:
 * `vsphere.datastore_get` - Fixed action to allow passing ids or names and still work properly. Fixed duplicate check so its working now and the same item is not added twice to the list when specifing name or id.
 * `vsphere.network_get` - Fixed action to allow passing ids or names and still work properly. Fixed duplicate check so its working now and the same item is not added twice to the list when specifing name or id.
 * `vsphere.get_tags_from_objects` - Fixed action to handle tag categories that can have multiple values. Fixed duplicate check so its working now and the same item is not added twice to the list when specifing name or id.
+* `vsphere.vm_hw_basic_build` - Converted from Mistral workflow to Orquesta workflow
 
 Contributed by Bradley Bishop (Encore Technologies).
 

--- a/actions/cluster_get.py
+++ b/actions/cluster_get.py
@@ -33,27 +33,23 @@ class ClusterGet(BaseAction):
         return return_dict
 
     def get_all(self):
-        results = []
         clusters = inventory.get_managed_entities(self.si_content, vim.ClusterComputeResource)
-        for cluster in clusters.view:
-            results.append(self.get_cluster_dict(cluster))
-
-        return results
+        return [self.get_cluster_dict(c) for c in clusters.view]
 
     def get_by_id_or_name(self, cluster_ids=[], cluster_names=[]):
-        results = []
+        results = {}
 
         for cid in cluster_ids:
             cluster = inventory.get_cluster(self.si_content, moid=cid)
             if cluster and cluster.name not in results:
-                results.append(self.get_cluster_dict(cluster))
+                results[cluster.name] = self.get_cluster_dict(cluster)
 
         for cluster in cluster_names:
             cluster = inventory.get_cluster(self.si_content, name=cluster)
             if cluster and cluster.name not in results:
-                results.append(self.get_cluster_dict(cluster))
+                results[cluster.name] = self.get_cluster_dict(cluster)
 
-        return results
+        return list(results.values())
 
     def run(self, cluster_ids, cluster_names, vsphere=None):
         """

--- a/actions/cluster_get.py
+++ b/actions/cluster_get.py
@@ -1,0 +1,79 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib import inventory
+from vmwarelib.serialize import ClusterGetJSONEncoder
+from vmwarelib.actions import BaseAction
+from pyVmomi import vim  # pylint: disable-msg=E0611
+import json
+
+
+class ClusterGet(BaseAction):
+    def get_cluster_dict(self, cluster):
+        summary = json.loads(json.dumps(cluster.summary, cls=ClusterGetJSONEncoder))
+        return_dict = {
+            'name': cluster.name,
+            # extract moid from vim.ManagedEntity object
+            'id': str(cluster).split(':')[-1].replace("'", ""),
+            'summary': summary
+        }
+
+        return return_dict
+
+    def get_all(self):
+        results = []
+        clusters = inventory.get_managed_entities(self.si_content, vim.ClusterComputeResource)
+        for cluster in clusters.view:
+            results.append(self.get_cluster_dict(cluster))
+
+        return results
+
+    def get_by_id_or_name(self, cluster_ids=[], cluster_names=[]):
+        results = []
+
+        for cid in cluster_ids:
+            cluster = inventory.get_cluster(self.si_content, moid=cid)
+            if cluster and cluster.name not in results:
+                results.append(self.get_cluster_dict(cluster))
+
+        for cluster in cluster_names:
+            cluster = inventory.get_cluster(self.si_content, name=cluster)
+            if cluster and cluster.name not in results:
+                results.append(self.get_cluster_dict(cluster))
+
+        return results
+
+    def run(self, cluster_ids, cluster_names, vsphere=None):
+        """
+        Retrieve summary information for given clusters (ESXi)
+
+        Args:
+        - cluster_ids: Moid of cluster to retrieve
+        - cluster_names: Name of cluster to retrieve
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+
+        Returns:
+        - array: Datastore objects
+        """
+        return_results = []
+
+        self.establish_connection(vsphere)
+
+        if not cluster_ids and not cluster_names:
+            return_results = self.get_all()
+        else:
+            return_results = self.get_by_id_or_name(cluster_ids, cluster_names)
+
+        return return_results

--- a/actions/cluster_get.yaml
+++ b/actions/cluster_get.yaml
@@ -1,19 +1,19 @@
 ---
-name: datastore_get
+name: cluster_get
 pack: vsphere
 runner_type: python-script
-description: Retrieve summary information for given Datastores or All Datastores if none are given
-entry_point: datastore_get.py
+description: Retrieve summary information for given Clusters or All Clusters if none are given
+entry_point: cluster_get.py
 parameters:
-  datastore_ids:
+  cluster_ids:
     type: array
-    description: Comma seperated list of Datastore IDs
+    description: Comma seperated list of Cluster IDs
     required: false
     position: 0
     default: []
-  datastore_names:
+  cluster_names:
     type: array
-    description: Comma seperated list of Datastore Names
+    description: Comma seperated list of Cluster Names
     required: false
     position: 1
     default: []

--- a/actions/datacenter_get.py
+++ b/actions/datacenter_get.py
@@ -1,0 +1,80 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib import inventory
+from vmwarelib.serialize import DatacenterGetJSONEncoder
+from vmwarelib.actions import BaseAction
+from pyVmomi import vim  # pylint: disable-msg=E0611
+import json
+
+
+class DatacenterGet(BaseAction):
+    def get_datacenter_dict(self, datacenter):
+        configuration = json.loads(json.dumps(datacenter.configuration,
+                                              cls=DatacenterGetJSONEncoder))
+        return_dict = {
+            'name': datacenter.name,
+            # extract moid from vim.ManagedEntity object
+            'id': str(datacenter).split(':')[-1].replace("'", ""),
+            'configuration': configuration
+        }
+
+        return return_dict
+
+    def get_all(self):
+        results = []
+        datacenters = inventory.get_managed_entities(self.si_content, vim.Datacenter)
+        for datacenter in datacenters.view:
+            results.append(self.get_datacenter_dict(datacenter))
+
+        return results
+
+    def get_by_id_or_name(self, datacenter_ids=[], datacenter_names=[]):
+        results = []
+
+        for did in datacenter_ids:
+            datacenter = inventory.get_datacenter(self.si_content, moid=did)
+            if datacenter and datacenter.name not in results:
+                results.append(self.get_datacenter_dict(datacenter))
+
+        for datacenter in datacenter_names:
+            datacenter = inventory.get_datacenter(self.si_content, name=datacenter)
+            if datacenter and datacenter.name not in results:
+                results.append(self.get_datacenter_dict(datacenter))
+
+        return results
+
+    def run(self, datacenter_ids, datacenter_names, vsphere=None):
+        """
+        Retrieve summary information for given datacenters (ESXi)
+
+        Args:
+        - datacenter_ids: Moid of datacenter to retrieve
+        - datacenter_names: Name of datacenter to retrieve
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+
+        Returns:
+        - array: Datacenter objects
+        """
+        return_results = []
+
+        self.establish_connection(vsphere)
+
+        if not datacenter_ids and not datacenter_names:
+            return_results = self.get_all()
+        else:
+            return_results = self.get_by_id_or_name(datacenter_ids, datacenter_names)
+
+        return return_results

--- a/actions/datacenter_get.py
+++ b/actions/datacenter_get.py
@@ -34,27 +34,23 @@ class DatacenterGet(BaseAction):
         return return_dict
 
     def get_all(self):
-        results = []
         datacenters = inventory.get_managed_entities(self.si_content, vim.Datacenter)
-        for datacenter in datacenters.view:
-            results.append(self.get_datacenter_dict(datacenter))
-
-        return results
+        return [self.get_datacenter_dict(d) for d in datacenters.view]
 
     def get_by_id_or_name(self, datacenter_ids=[], datacenter_names=[]):
-        results = []
+        results = {}
 
         for did in datacenter_ids:
             datacenter = inventory.get_datacenter(self.si_content, moid=did)
             if datacenter and datacenter.name not in results:
-                results.append(self.get_datacenter_dict(datacenter))
+                results[datacenter.name] = self.get_datacenter_dict(datacenter)
 
         for datacenter in datacenter_names:
             datacenter = inventory.get_datacenter(self.si_content, name=datacenter)
             if datacenter and datacenter.name not in results:
-                results.append(self.get_datacenter_dict(datacenter))
+                results[datacenter.name] = self.get_datacenter_dict(datacenter)
 
-        return results
+        return list(results.values())
 
     def run(self, datacenter_ids, datacenter_names, vsphere=None):
         """

--- a/actions/datacenter_get.yaml
+++ b/actions/datacenter_get.yaml
@@ -1,19 +1,19 @@
 ---
-name: datastore_get
+name: datacenter_get
 pack: vsphere
 runner_type: python-script
-description: Retrieve summary information for given Datastores or All Datastores if none are given
-entry_point: datastore_get.py
+description: Retrieve summary information for given Datacenters or All Datacenters if none are given
+entry_point: datacenter_get.py
 parameters:
-  datastore_ids:
+  datacenter_ids:
     type: array
-    description: Comma seperated list of Datastore IDs
+    description: Comma seperated list of Datacenter IDs
     required: false
     position: 0
     default: []
-  datastore_names:
+  datacenter_names:
     type: array
-    description: Comma seperated list of Datastore Names
+    description: Comma seperated list of Datacenter Names
     required: false
     position: 1
     default: []

--- a/actions/datastore_get.py
+++ b/actions/datastore_get.py
@@ -32,27 +32,23 @@ class DatastoreGet(BaseAction):
         return return_dict
 
     def get_all(self):
-        results = []
         datastores = inventory.get_managed_entities(self.si_content, vim.Datastore)
-        for datastore in datastores.view:
-            results.append(self.get_datastore_dict(datastore))
-
-        return results
+        return [self.get_datastore_dict(d) for d in datastores.view]
 
     def get_by_id_or_name(self, datastore_ids=[], datastore_names=[]):
-        results = []
+        results = {}
 
         for did in datastore_ids:
             datastore = inventory.get_datastore(self.si_content, moid=did)
             if datastore and datastore.name not in results:
-                results.append(self.get_datastore_dict(datastore))
+                results[datastore.name] = self.get_datastore_dict(datastore)
 
         for datastore in datastore_names:
             datastore = inventory.get_datastore(self.si_content, name=datastore)
             if datastore and datastore.name not in results:
-                results.append(self.get_datastore_dict(datastore))
+                results[datastore.name] = self.get_datastore_dict(datastore)
 
-        return results
+        return list(results.values())
 
     def run(self, datastore_ids, datastore_names, vsphere=None):
         """

--- a/actions/get_tags_from_objects.py
+++ b/actions/get_tags_from_objects.py
@@ -22,7 +22,11 @@ class GetTagsFromObjects(BaseAction):
         for obj in obj_tags:
             tag = self.tagging.tag_get(obj)
             category = self.tagging.category_get(tag['category_id'])
-            tags[category['name']] = tag['name']
+
+            # Categories can have multiple tags associated to them
+            if category['name'] not in tags:
+                tags[category['name']] = []
+            tags[category['name']].append(tag['name'])
 
         # dictionary of category name: tag name
         return tags

--- a/actions/network_get.py
+++ b/actions/network_get.py
@@ -37,27 +37,23 @@ class NetworkGet(BaseAction):
         return return_dict
 
     def get_all(self):
-        results = []
         networks = inventory.get_managed_entities(self.si_content, vim.Network)
-        for network in networks.view:
-            results.append(self.get_network_dict(network))
-
-        return results
+        return [self.get_network_dict(n) for n in networks.view]
 
     def get_by_id_or_name(self, network_ids=[], network_names=[]):
-        results = []
+        results = {}
 
         for did in network_ids:
             network = inventory.get_network(self.si_content, moid=did)
             if network and network.name not in results:
-                results.append(self.get_network_dict(network))
+                results[network.name] = self.get_network_dict(network)
 
         for network in network_names:
             network = inventory.get_network(self.si_content, name=network)
             if network and network.name not in results:
-                results.append(self.get_network_dict(network))
+                results[network.name] = self.get_network_dict(network)
 
-        return results
+        return list(results.values())
 
     def run(self, network_ids, network_names, vsphere=None):
         """

--- a/actions/network_get.yaml
+++ b/actions/network_get.yaml
@@ -10,12 +10,13 @@ parameters:
     description: Comma seperated list of network IDs
     required: false
     position: 0
+    default: []
   network_names:
     type: array
     description: Comma seperated list of network Names
     required: false
     position: 1
-    default: ~
+    default: []
   vsphere:
     type: string
     description: Pre-configured vsphere endpoint

--- a/actions/template_get.py
+++ b/actions/template_get.py
@@ -40,19 +40,19 @@ class TemplateGet(BaseAction):
         return results
 
     def get_by_id_or_name(self, template_ids=[], template_names=[]):
-        results = []
+        results = {}
 
         for tid in template_ids:
             template = inventory.get_virtualmachine(self.si_content, moid=tid)
             if template and template.config.template and template.name not in results:
-                results.append(self.get_template_dict(template))
+                results[template.name] = self.get_template_dict(template)
 
         for template in template_names:
             template = inventory.get_virtualmachine(self.si_content, name=template)
             if template and template.config.template and template.name not in results:
-                results.append(self.get_template_dict(template))
+                results[template.name] = self.get_template_dict(template)
 
-        return results
+        return list(results.values())
 
     def run(self, template_ids, template_names, vsphere=None):
         """

--- a/actions/template_get.py
+++ b/actions/template_get.py
@@ -1,0 +1,78 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib import inventory
+from vmwarelib.serialize import TemplateGetJSONEncoder
+from vmwarelib.actions import BaseAction
+import json
+
+
+class TemplateGet(BaseAction):
+    def get_template_dict(self, template):
+        summary = json.loads(json.dumps(template.summary, cls=TemplateGetJSONEncoder))
+        return_dict = {
+            'name': template.name,
+            'id': summary['vm']['_moId'],
+            'summary': summary
+        }
+
+        return return_dict
+
+    def get_all(self):
+        results = []
+        templates = inventory.get_virtualmachines(self.si_content)
+        for template in templates.view:
+            if template.config.template:
+                results.append(self.get_template_dict(template))
+
+        return results
+
+    def get_by_id_or_name(self, template_ids=[], template_names=[]):
+        results = []
+
+        for tid in template_ids:
+            template = inventory.get_virtualmachine(self.si_content, moid=tid)
+            if template and template.config.template and template.name not in results:
+                results.append(self.get_template_dict(template))
+
+        for template in template_names:
+            template = inventory.get_virtualmachine(self.si_content, name=template)
+            if template and template.config.template and template.name not in results:
+                results.append(self.get_template_dict(template))
+
+        return results
+
+    def run(self, template_ids, template_names, vsphere=None):
+        """
+        Retrieve summary information for given templates (ESXi)
+
+        Args:
+        - template_ids: Moid of template to retrieve
+        - template_names: Name of template to retrieve
+        - vsphere: Pre-configured vsphere connection details (config.yaml)
+
+        Returns:
+        - array: Template objects
+        """
+        return_results = []
+
+        self.establish_connection(vsphere)
+
+        if not template_ids and not template_names:
+            return_results = self.get_all()
+        else:
+            return_results = self.get_by_id_or_name(template_ids, template_names)
+
+        return return_results

--- a/actions/template_get.yaml
+++ b/actions/template_get.yaml
@@ -1,19 +1,19 @@
 ---
-name: datastore_get
+name: template_get
 pack: vsphere
 runner_type: python-script
-description: Retrieve summary information for given Datastores or All Datastores if none are given
-entry_point: datastore_get.py
+description: Retrieve summary information for given Templates or All Templates if none are given
+entry_point: template_get.py
 parameters:
-  datastore_ids:
+  template_ids:
     type: array
-    description: Comma seperated list of Datastore IDs
+    description: Comma seperated list of Template IDs
     required: false
     position: 0
     default: []
-  datastore_names:
+  template_names:
     type: array
-    description: Comma seperated list of Datastore Names
+    description: Comma seperated list of Template Names
     required: false
     position: 1
     default: []

--- a/actions/vm_hw_basic_build.yaml
+++ b/actions/vm_hw_basic_build.yaml
@@ -1,86 +1,85 @@
 ---
-name: "vm_hw_basic_build"
-runner_type: "mistral-v2"
-pack: "vsphere"
+name: vm_hw_basic_build
+runner_type: orquesta
+pack: vsphere
 enabled: true
-entry_point: 'workflows/vm_hw_basic_build.yaml'
+entry_point: workflows/vm_hw_basic_build.yaml
 description: WorkFlow to build a base VM hardware and optional power on (CPU, RAM, HDD, NIC)
-
 parameters:
   vsphere:
     type: string
     description: Pre-Configured Vsphere Connection
     default: ~
     position: 1
-  vm_name: 
+  vm_name:
     required: true
-    type: string 
-    position: 0
-  vm_hdd_dscluster: 
     type: string
-    description: Which Datastore Cluster should be used for this HDD. Blank = same as Base VM    
-  vm_resourcepool: 
+    position: 0
+  vm_hdd_dscluster:
+    type: string
+    description: Which Datastore Cluster should be used for this HDD. Blank = same as Base VM
+  vm_resourcepool:
     type: string
     position: 4
-  vm_version: 
+  vm_version:
     default: vmx-09
     type: string
     description: Virtual Machine Hardware Version
-  vm_cpu: 
+  vm_cpu:
     default: 1
     type: integer
     description: Number of CPU's to attach to this VM
     position: 5
-  vm_ram: 
+  vm_ram:
     default: 2
     type: integer
     description: RAM (GB) assigned to server)
     position: 6
-  vm_ctrl_type: 
+  vm_ctrl_type:
     default: ParaVirtual
     type: string
     description: Type of HDD SCSI Controller to be used on this machine
-  vm_hdd_size: 
+  vm_hdd_size:
     default: 40
     type: integer
     description: Size of HDD in GB
     position: 9
-  vm_nic_type: 
+  vm_nic_type:
     default: vmxnet3
     type: string
     description: Type of Network Adapter to attach
     position: 10
-  vm_nic_netname: 
+  vm_nic_netname:
     required: true
     type: string
     description: Which network do you want to attach to?
     position: 11
-  vm_dscluster: 
+  vm_dscluster:
     required: false
     type: string
     description: Datastore Cluster core VM Files will be store against (vmx files).
     position: 8
-  vm_datastore: 
+  vm_datastore:
     required: false
     type: string
     description: Datastore core VM Files will be store against (vmx files). Use unless datastoreCluster is provided.
     position: 7
-  vm_dc: 
+  vm_dc:
     required: false
     default: ~
     type: string
     description: DataCenter to Buid VM within
     position: 2
-  vm_dccluster: 
+  vm_dccluster:
     required: true
     type: string
     description: DataCenter Cluster to Buid VM within
     position: 3
-  vm_guestos: 
+  vm_guestos:
     default: rhel6_64guest
     type: string
     position: 12
-  vm_description: 
+  vm_description:
     description: Simple description about Virtual Machine
     type: string
     position: 13

--- a/actions/vmwarelib/serialize.py
+++ b/actions/vmwarelib/serialize.py
@@ -85,6 +85,33 @@ DATASTORE_GET_NON_JSON_SERILIZABLE_TYPES = [
     vim.Datastore.Summary
 ]
 
+DATACENTER_GET_NON_JSON_SERILIZABLE_TYPES = [
+    vim.Datacenter,
+    vim.Datacenter.ConfigInfo
+]
+
+TEMPLATE_GET_NON_JSON_SERILIZABLE_TYPES = [
+    vim.vm,
+    vim.VirtualMachine,
+    vim.vm.Summary,
+    vim.vm.RuntimeInfo,
+    vim.vm.DeviceRuntimeInfo,
+    vim.vm.DeviceRuntimeInfo.VirtualEthernetCardRuntimeState,
+    vim.vm.FeatureRequirement,
+    vim.vm.Summary.GuestSummary,
+    vim.vm.Summary.ConfigSummary,
+    vim.vm.Summary.StorageSummary,
+    vim.vm.Summary.QuickStats
+]
+
+CLUSTER_GET_NON_JSON_SERILIZABLE_TYPES = [
+    vim.ClusterComputeResource,
+    vim.ClusterComputeResource.Summary,
+    vim.cluster.DasDataSummary,
+    vim.cluster.FailoverLevelAdmissionControlInfo,
+    vim.cluster.FailoverResourcesAdmissionControlInfo
+]
+
 NETWORK_GET_NON_JSON_SERILIZABLE_TYPES = [
     vim.Network,
     vim.Network.Summary,
@@ -122,6 +149,42 @@ class DatastoreGetJSONEncoder(json.JSONEncoder):
             return super(DatastoreGetJSONEncoder, self).default(obj)
         except TypeError:
             if type(obj) in DATASTORE_GET_NON_JSON_SERILIZABLE_TYPES:
+                return obj.__dict__
+
+            # For anything else just return the class name
+            return "__{}__".format(obj.__class__.__name__)
+
+
+class DatacenterGetJSONEncoder(json.JSONEncoder):
+    def default(self, obj):  # pylint: disable=E0202
+        try:
+            return super(DatacenterGetJSONEncoder, self).default(obj)
+        except TypeError:
+            if type(obj) in DATACENTER_GET_NON_JSON_SERILIZABLE_TYPES:
+                return obj.__dict__
+
+            # For anything else just return the class name
+            return "__{}__".format(obj.__class__.__name__)
+
+
+class ClusterGetJSONEncoder(json.JSONEncoder):
+    def default(self, obj):  # pylint: disable=E0202
+        try:
+            return super(ClusterGetJSONEncoder, self).default(obj)
+        except TypeError:
+            if type(obj) in CLUSTER_GET_NON_JSON_SERILIZABLE_TYPES:
+                return obj.__dict__
+
+            # For anything else just return the class name
+            return "__{}__".format(obj.__class__.__name__)
+
+
+class TemplateGetJSONEncoder(json.JSONEncoder):
+    def default(self, obj):  # pylint: disable=E0202
+        try:
+            return super(TemplateGetJSONEncoder, self).default(obj)
+        except TypeError:
+            if type(obj) in TEMPLATE_GET_NON_JSON_SERILIZABLE_TYPES:
                 return obj.__dict__
 
             # For anything else just return the class name

--- a/actions/workflows/vm_hw_basic_build.yaml
+++ b/actions/workflows/vm_hw_basic_build.yaml
@@ -1,86 +1,98 @@
 ---
-version: '2.0'
+version: '1.0'
 
-vsphere.vm_hw_basic_build:
-  description: "Create a Simple VM (CPU, Ram, HDD, NIC) and then Power it on"
-  input:
-    - vsphere
-    - vm_name
-    - vm_resourcepool
-    - vm_cpu
-    - vm_ram
-    - vm_dscluster
-    - vm_datastore
-    - vm_dccluster
-    - vm_dc
-    - vm_guestos
-    - vm_description
-    - vm_ctrl_type
-    - vm_hdd_size
-    - vm_hdd_dscluster
-    - vm_nic_type
-    - vm_nic_netname
-    - vm_version
-    - vm_poweron
-  tasks:
-    barebones_build:
-      # [189, 97]
-      action: vsphere.vm_hw_barebones_create
-      wait-after: 12
-      input:
-        vm_name: <% $.vm_name %>
-        ram_size: <% $.vm_ram %>
-        cpu_size: <% $.vm_cpu %>
-        cluster: <% $.vm_dccluster %>
-        datacenter: <% $.vm_dc %>
-        datastore_cluster: <% $.vm_dscluster %>
-        datastore: <% $.vm_datastore %>
-        resourcepool: <% $.vm_resourcepool %>
-        version: <% $.vm_version %>
-        guestos: <% $.vm_guestos %>
-        description: <% $.vm_description %>
-        vsphere: <% $.vsphere %>
-      publish:
-        vm_id: <% task(barebones_build).result.result.vm_id %>
-      on-success:
-        - add_controller
-    add_controller:
-      # [186, 198]
-      action: vsphere.vm_hw_scsi_controller_add
-      wait-after: 12
-      input:
-        vm_id: <% $.vm_id %>
-        controller_type: <% $.vm_ctrl_type %>
-        vsphere: <% $.vsphere %>
-      on-success:
-        - add_hdd
-    add_hdd:
-      # [188, 302]
-      action: vsphere.vm_hw_hdd_add
-      wait-after: 12
-      input: 
-        vm_id: <% $.vm_id %>
-        datastore_cluster: <% $.vm_hdd_dscluster %>
-        disk_size: <% $.vm_hdd_size %>
-        provision_type: "thin"
-        vsphere: <% $.vsphere %>
-      on-success:
-        - add_nic
-    add_nic:
-      # [189, 404]
-      action: vsphere.vm_hw_nic_add
-      wait-after: 12
-      input:
-        vm_id: <% $.vm_id %>
-        network_name: <% $.vm_nic_netname %>
-        nictype: <% $.vm_nic_type %>
-        vsphere: <% $.vsphere %>
-      on-success:
-        - power_on: <% $.vm_poweron = true %>
-    power_on:
-      # [190, 505]
-      action: vsphere.vm_hw_power_on
-      wait-after: 12
-      input:
-        vm_id: <% $.vm_id %>
-        vsphere: <% $.vsphere %>
+description: "Create a Simple VM (CPU, Ram, HDD, NIC) and then Power it on"
+
+input:
+  - vsphere
+  - vm_name
+  - vm_resourcepool
+  - vm_cpu
+  - vm_ram
+  - vm_dscluster
+  - vm_datastore
+  - vm_dccluster
+  - vm_dc
+  - vm_guestos
+  - vm_description
+  - vm_ctrl_type
+  - vm_hdd_size
+  - vm_hdd_dscluster
+  - vm_nic_type
+  - vm_nic_netname
+  - vm_version
+  - vm_poweron
+
+tasks:
+  barebones_build:
+    # [189, 97]
+    action: vsphere.vm_hw_barebones_create
+    input:
+      vm_name: "{{ ctx().vm_name }}"
+      ram_size: "{{ ctx().vm_ram }}"
+      cpu_size: "{{ ctx().vm_cpu }}"
+      cluster: "{{ ctx().vm_dccluster }}"
+      datacenter: "{{ ctx().vm_dc }}"
+      datastore_cluster: "{{ ctx().vm_dscluster }}"
+      datastore: "{{ ctx().vm_datastore }}"
+      resourcepool: "{{ ctx().vm_resourcepool }}"
+      version: "{{ ctx().vm_version }}"
+      guestos: "{{ ctx().vm_guestos }}"
+      description: "{{ ctx().vm_description }}"
+      vsphere: "{{ ctx().vsphere }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - vm_id: "{{ result().result.vm_id }}"
+        do:
+          - add_controller
+
+  add_controller:
+    # [186, 198]
+    action: vsphere.vm_hw_scsi_controller_add
+    delay: 12
+    input:
+      vm_id: "{{ ctx().vm_id }}"
+      controller_type: "{{ ctx().vm_ctrl_type }}"
+      vsphere: "{{ ctx().vsphere }}"
+    next:
+      - when: "{{ succeeded() }}"
+        do:
+          - add_hdd
+
+  add_hdd:
+    # [188, 302]
+    action: vsphere.vm_hw_hdd_add
+    delay: 12
+    input:
+      vm_id: "{{ ctx().vm_id }}"
+      datastore_cluster: "{{ ctx().vm_hdd_dscluster }}"
+      disk_size: "{{ ctx().vm_hdd_size }}"
+      provision_type: "thin"
+      vsphere: "{{ ctx().vsphere }}"
+    next:
+      - when: "{{ succeeded() }}"
+        do:
+          - add_nic
+
+  add_nic:
+    # [189, 404]
+    action: vsphere.vm_hw_nic_add
+    delay: 12
+    input:
+      vm_id: "{{ ctx().vm_id }}"
+      network_name: "{{ ctx().vm_nic_netname }}"
+      nictype: "{{ ctx().vm_nic_type }}"
+      vsphere: "{{ ctx().vsphere }}"
+    next:
+      - when: "{{ succeeded() and ctx().vm_poweron }}"
+        do:
+          - power_on
+
+  power_on:
+    # [190, 505]
+    action: vsphere.vm_hw_power_on
+    delay: 12
+    input:
+      vm_id: "{{ ctx().vm_id }}"
+      vsphere: "{{ ctx().vsphere }}"

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.15.0
+version: 0.15.1
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.15.1
+version: 0.15.0
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.14.0
+version: 0.15.0
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/tests/test_action_cluster_get.py
+++ b/tests/test_action_cluster_get.py
@@ -110,17 +110,42 @@ class ClusterGetTestCase(VsphereBaseActionTestCase):
                 'id': '4',
                 'summary': expected_summary_4
             }, {
-                'name': 'test_cluster_2',
-                'id': '2',
-                'summary': expected_summary_2
-            }, {
                 'name': 'test_cluster_5',
                 'id': '5',
                 'summary': expected_summary_5
+            }, {
+                'name': 'test_cluster_2',
+                'id': '2',
+                'summary': expected_summary_2
             }
         ]
 
         result = self._action.get_by_id_or_name([4], ['test_cluster_2', 'test_cluster_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name_duplicate(self):
+        cluster_1 = mock.Mock()
+        cluster_1.__str__ = mock.Mock(return_value="''vim.Cluster:1''")
+        cluster_1_name_property = mock.PropertyMock(return_value='test_cluster')
+        type(cluster_1).name = cluster_1_name_property
+        expected_summary_1 = {'numHosts': '1'}
+        cluster_1.summary = expected_summary_1
+        cluster_1._moId = 1
+
+        mock_view = mock.Mock(view=[cluster_1])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_cluster',
+                'id': '1',
+                'summary': expected_summary_1
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([1], ['test_cluster'])
         self.assertEqual(result, expected_result)
 
     def test_get_all_clusters(self):
@@ -216,13 +241,13 @@ class ClusterGetTestCase(VsphereBaseActionTestCase):
                 'id': '4',
                 'summary': expected_summary_4
             }, {
-                'name': 'test_cluster_2',
-                'id': '2',
-                'summary': expected_summary_2
-            }, {
                 'name': 'test_cluster_5',
                 'id': '5',
                 'summary': expected_summary_5
+            }, {
+                'name': 'test_cluster_2',
+                'id': '2',
+                'summary': expected_summary_2
             }
         ]
 

--- a/tests/test_action_cluster_get.py
+++ b/tests/test_action_cluster_get.py
@@ -1,0 +1,307 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+# from vmwarelib import inventory
+from cluster_get import ClusterGet
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'ClusterGet'
+]
+
+
+class ClusterGetTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = ClusterGet
+
+    def setUp(self):
+        super(ClusterGetTestCase, self).setUp()
+
+        self._action = self.get_action_instance(self.new_config)
+
+        self._action.establish_connection = mock.Mock()
+        self._action.si_content = mock.Mock()
+
+    def test_get_cluster_dict(self):
+        cluster_1 = mock.Mock()
+        cluster_1.__str__ = mock.Mock(return_value="''vim.Cluster:1''")
+        cluster_1_name_property = mock.PropertyMock(return_value='test_cluster')
+        type(cluster_1).name = cluster_1_name_property
+        expected_summary = {'numHosts': '1'}
+        cluster_1.summary = expected_summary
+        cluster_1._moId = 1
+
+        expected_result = {
+            'name': 'test_cluster',
+            'id': '1',
+            'summary': expected_summary
+        }
+
+        result = self._action.get_cluster_dict(cluster_1)
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name(self):
+        cluster_1 = mock.Mock()
+        cluster_1.__str__ = mock.Mock(return_value="''vim.Cluster:1''")
+        cluster_1_name_property = mock.PropertyMock(return_value='test_cluster')
+        type(cluster_1).name = cluster_1_name_property
+        expected_summary_1 = {'numHosts': '1'}
+        cluster_1.summary = expected_summary_1
+        cluster_1._moId = 1
+
+        cluster_2 = mock.Mock()
+        cluster_2.__str__ = mock.Mock(return_value="''vim.Cluster:2''")
+        cluster_2_name_property = mock.PropertyMock(return_value='test_cluster_2')
+        type(cluster_2).name = cluster_2_name_property
+        expected_summary_2 = {'numHosts': '1'}
+        cluster_2.summary = expected_summary_2
+        cluster_2._moId = 2
+
+        cluster_3 = mock.Mock()
+        cluster_3.__str__ = mock.Mock(return_value="''vim.Cluster:3''")
+        cluster_3_name_property = mock.PropertyMock(return_value='test_cluster_3')
+        type(cluster_3).name = cluster_3_name_property
+        expected_summary_3 = {'numHosts': '1'}
+        cluster_3.summary = expected_summary_3
+        cluster_3._moId = 3
+
+        cluster_4 = mock.Mock()
+        cluster_4.__str__ = mock.Mock(return_value="''vim.Cluster:4''")
+        cluster_4_name_property = mock.PropertyMock(return_value='test_cluster_4')
+        type(cluster_4).name = cluster_4_name_property
+        expected_summary_4 = {'numHosts': '1'}
+        cluster_4.summary = expected_summary_4
+        cluster_4._moId = 4
+
+        cluster_5 = mock.Mock()
+        cluster_5.__str__ = mock.Mock(return_value="''vim.Cluster:5''")
+        cluster_5_name_property = mock.PropertyMock(return_value='test_cluster_5')
+        type(cluster_5).name = cluster_5_name_property
+        expected_summary_5 = {'numHosts': '1'}
+        cluster_5.summary = expected_summary_5
+        cluster_5._moId = 5
+
+        mock_view = mock.Mock(view=[cluster_1,
+                                    cluster_2,
+                                    cluster_3,
+                                    cluster_4,
+                                    cluster_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_cluster_4',
+                'id': '4',
+                'summary': expected_summary_4
+            }, {
+                'name': 'test_cluster_2',
+                'id': '2',
+                'summary': expected_summary_2
+            }, {
+                'name': 'test_cluster_5',
+                'id': '5',
+                'summary': expected_summary_5
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([4], ['test_cluster_2', 'test_cluster_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_all_clusters(self):
+        cluster_1 = mock.Mock()
+        cluster_1.__str__ = mock.Mock(return_value="''vim.Cluster:1''")
+        cluster_1_name_property = mock.PropertyMock(return_value='test_cluster')
+        type(cluster_1).name = cluster_1_name_property
+        expected_summary_1 = {'numHosts': '1'}
+        cluster_1.summary = expected_summary_1
+        cluster_1._moId = 1
+
+        cluster_2 = mock.Mock()
+        cluster_2.__str__ = mock.Mock(return_value="''vim.Cluster:2''")
+        cluster_2_name_property = mock.PropertyMock(return_value='test_cluster_2')
+        type(cluster_2).name = cluster_2_name_property
+        expected_summary_2 = {'numHosts': '1'}
+        cluster_2.summary = expected_summary_2
+        cluster_2._moId = 2
+
+        mock_view = mock.Mock(view=[cluster_1, cluster_2])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_cluster',
+                'id': '1',
+                'summary': expected_summary_1
+            }, {
+                'name': 'test_cluster_2',
+                'id': '2',
+                'summary': expected_summary_2
+            }
+        ]
+
+        result = self._action.get_all()
+        self.assertEqual(result, expected_result)
+
+    def test_run_get_by_id_or_name(self):
+        cluster_1 = mock.Mock()
+        cluster_1.__str__ = mock.Mock(return_value="''vim.Cluster:1''")
+        cluster_1_name_property = mock.PropertyMock(return_value='test_cluster')
+        type(cluster_1).name = cluster_1_name_property
+        expected_summary_1 = {'numHosts': '1'}
+        cluster_1.summary = expected_summary_1
+        cluster_1._moId = 1
+
+        cluster_2 = mock.Mock()
+        cluster_2.__str__ = mock.Mock(return_value="''vim.Cluster:2''")
+        cluster_2_name_property = mock.PropertyMock(return_value='test_cluster_2')
+        type(cluster_2).name = cluster_2_name_property
+        expected_summary_2 = {'numHosts': '1'}
+        cluster_2.summary = expected_summary_2
+        cluster_2._moId = 2
+
+        cluster_3 = mock.Mock()
+        cluster_3.__str__ = mock.Mock(return_value="''vim.Cluster:3''")
+        cluster_3_name_property = mock.PropertyMock(return_value='test_cluster_3')
+        type(cluster_3).name = cluster_3_name_property
+        expected_summary_3 = {'numHosts': '1'}
+        cluster_3.summary = expected_summary_3
+        cluster_3._moId = 3
+
+        cluster_4 = mock.Mock()
+        cluster_4.__str__ = mock.Mock(return_value="''vim.Cluster:4''")
+        cluster_4_name_property = mock.PropertyMock(return_value='test_cluster_4')
+        type(cluster_4).name = cluster_4_name_property
+        expected_summary_4 = {'numHosts': '1'}
+        cluster_4.summary = expected_summary_4
+        cluster_4._moId = 4
+
+        cluster_5 = mock.Mock()
+        cluster_5.__str__ = mock.Mock(return_value="''vim.Cluster:5''")
+        cluster_5_name_property = mock.PropertyMock(return_value='test_cluster_5')
+        type(cluster_5).name = cluster_5_name_property
+        expected_summary_5 = {'numHosts': '1'}
+        cluster_5.summary = expected_summary_5
+        cluster_5._moId = 5
+
+        mock_view = mock.Mock(view=[cluster_1,
+                                    cluster_2,
+                                    cluster_3,
+                                    cluster_4,
+                                    cluster_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_cluster_4',
+                'id': '4',
+                'summary': expected_summary_4
+            }, {
+                'name': 'test_cluster_2',
+                'id': '2',
+                'summary': expected_summary_2
+            }, {
+                'name': 'test_cluster_5',
+                'id': '5',
+                'summary': expected_summary_5
+            }
+        ]
+
+        result = self._action.run([4], ['test_cluster_2', 'test_cluster_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_run_all(self):
+        cluster_1 = mock.Mock()
+        cluster_1.__str__ = mock.Mock(return_value="''vim.Cluster:1''")
+        cluster_1_name_property = mock.PropertyMock(return_value='test_cluster')
+        type(cluster_1).name = cluster_1_name_property
+        expected_summary_1 = {'numHosts': '1'}
+        cluster_1.summary = expected_summary_1
+        cluster_1._moId = 1
+
+        cluster_2 = mock.Mock()
+        cluster_2.__str__ = mock.Mock(return_value="''vim.Cluster:2''")
+        cluster_2_name_property = mock.PropertyMock(return_value='test_cluster_2')
+        type(cluster_2).name = cluster_2_name_property
+        expected_summary_2 = {'numHosts': '1'}
+        cluster_2.summary = expected_summary_2
+        cluster_2._moId = 2
+
+        cluster_3 = mock.Mock()
+        cluster_3.__str__ = mock.Mock(return_value="''vim.Cluster:3''")
+        cluster_3_name_property = mock.PropertyMock(return_value='test_cluster_3')
+        type(cluster_3).name = cluster_3_name_property
+        expected_summary_3 = {'numHosts': '1'}
+        cluster_3.summary = expected_summary_3
+        cluster_3._moId = 3
+
+        cluster_4 = mock.Mock()
+        cluster_4.__str__ = mock.Mock(return_value="''vim.Cluster:4''")
+        cluster_4_name_property = mock.PropertyMock(return_value='test_cluster_4')
+        type(cluster_4).name = cluster_4_name_property
+        expected_summary_4 = {'numHosts': '1'}
+        cluster_4.summary = expected_summary_4
+        cluster_4._moId = 4
+
+        cluster_5 = mock.Mock()
+        cluster_5.__str__ = mock.Mock(return_value="''vim.Cluster:5''")
+        cluster_5_name_property = mock.PropertyMock(return_value='test_cluster_5')
+        type(cluster_5).name = cluster_5_name_property
+        expected_summary_5 = {'numHosts': '1'}
+        cluster_5.summary = expected_summary_5
+        cluster_5._moId = 5
+
+        mock_view = mock.Mock(view=[cluster_1,
+                                    cluster_2,
+                                    cluster_3,
+                                    cluster_4,
+                                    cluster_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_cluster',
+                'id': '1',
+                'summary': expected_summary_1
+            }, {
+                'name': 'test_cluster_2',
+                'id': '2',
+                'summary': expected_summary_2
+            }, {
+                'name': 'test_cluster_3',
+                'id': '3',
+                'summary': expected_summary_3
+            }, {
+                'name': 'test_cluster_4',
+                'id': '4',
+                'summary': expected_summary_4
+            }, {
+                'name': 'test_cluster_5',
+                'id': '5',
+                'summary': expected_summary_5
+            }
+        ]
+
+        result = self._action.run(None, None)
+        self.assertEqual(result, expected_result)

--- a/tests/test_action_datacenter_get.py
+++ b/tests/test_action_datacenter_get.py
@@ -1,0 +1,307 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+# from vmwarelib import inventory
+from datacenter_get import DatacenterGet
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'DatacenterGet'
+]
+
+
+class DatacenterGetTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = DatacenterGet
+
+    def setUp(self):
+        super(DatacenterGetTestCase, self).setUp()
+
+        self._action = self.get_action_instance(self.new_config)
+
+        self._action.establish_connection = mock.Mock()
+        self._action.si_content = mock.Mock()
+
+    def test_get_datacenter_dict(self):
+        datacenter_1 = mock.Mock()
+        datacenter_1.__str__ = mock.Mock(return_value="''vim.Datacenter:1''")
+        datacenter_1_name_property = mock.PropertyMock(return_value='test_datacenter')
+        type(datacenter_1).name = datacenter_1_name_property
+        expected_configuration = {'defaultHardwareVersionKey': 'test'}
+        datacenter_1.configuration = expected_configuration
+        datacenter_1._moId = 1
+
+        expected_result = {
+            'name': 'test_datacenter',
+            'id': '1',
+            'configuration': expected_configuration
+        }
+
+        result = self._action.get_datacenter_dict(datacenter_1)
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name(self):
+        datacenter_1 = mock.Mock()
+        datacenter_1.__str__ = mock.Mock(return_value="''vim.Datacenter:1''")
+        datacenter_1_name_property = mock.PropertyMock(return_value='test_datacenter')
+        type(datacenter_1).name = datacenter_1_name_property
+        expected_configuration_1 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_1.configuration = expected_configuration_1
+        datacenter_1._moId = 1
+
+        datacenter_2 = mock.Mock()
+        datacenter_2.__str__ = mock.Mock(return_value="''vim.Datacenter:2''")
+        datacenter_2_name_property = mock.PropertyMock(return_value='test_datacenter_2')
+        type(datacenter_2).name = datacenter_2_name_property
+        expected_configuration_2 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_2.configuration = expected_configuration_2
+        datacenter_2._moId = 2
+
+        datacenter_3 = mock.Mock()
+        datacenter_3.__str__ = mock.Mock(return_value="''vim.Datacenter:3''")
+        datacenter_3_name_property = mock.PropertyMock(return_value='test_datacenter_3')
+        type(datacenter_3).name = datacenter_3_name_property
+        expected_configuration_3 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_3.configuration = expected_configuration_3
+        datacenter_3._moId = 3
+
+        datacenter_4 = mock.Mock()
+        datacenter_4.__str__ = mock.Mock(return_value="''vim.Datacenter:4''")
+        datacenter_4_name_property = mock.PropertyMock(return_value='test_datacenter_4')
+        type(datacenter_4).name = datacenter_4_name_property
+        expected_configuration_4 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_4.configuration = expected_configuration_4
+        datacenter_4._moId = 4
+
+        datacenter_5 = mock.Mock()
+        datacenter_5.__str__ = mock.Mock(return_value="''vim.Datacenter:5''")
+        datacenter_5_name_property = mock.PropertyMock(return_value='test_datacenter_5')
+        type(datacenter_5).name = datacenter_5_name_property
+        expected_configuration_5 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_5.configuration = expected_configuration_5
+        datacenter_5._moId = 5
+
+        mock_view = mock.Mock(view=[datacenter_1,
+                                    datacenter_2,
+                                    datacenter_3,
+                                    datacenter_4,
+                                    datacenter_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_datacenter_4',
+                'id': '4',
+                'configuration': expected_configuration_4
+            }, {
+                'name': 'test_datacenter_2',
+                'id': '2',
+                'configuration': expected_configuration_2
+            }, {
+                'name': 'test_datacenter_5',
+                'id': '5',
+                'configuration': expected_configuration_5
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([4], ['test_datacenter_2', 'test_datacenter_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_all_datacenters(self):
+        datacenter_1 = mock.Mock()
+        datacenter_1.__str__ = mock.Mock(return_value="''vim.Datacenter:1''")
+        datacenter_1_name_property = mock.PropertyMock(return_value='test_datacenter')
+        type(datacenter_1).name = datacenter_1_name_property
+        expected_configuration_1 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_1.configuration = expected_configuration_1
+        datacenter_1._moId = 1
+
+        datacenter_2 = mock.Mock()
+        datacenter_2.__str__ = mock.Mock(return_value="''vim.Datacenter:2''")
+        datacenter_2_name_property = mock.PropertyMock(return_value='test_datacenter_2')
+        type(datacenter_2).name = datacenter_2_name_property
+        expected_configuration_2 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_2.configuration = expected_configuration_2
+        datacenter_2._moId = 2
+
+        mock_view = mock.Mock(view=[datacenter_1, datacenter_2])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_datacenter',
+                'id': '1',
+                'configuration': expected_configuration_1
+            }, {
+                'name': 'test_datacenter_2',
+                'id': '2',
+                'configuration': expected_configuration_2
+            }
+        ]
+
+        result = self._action.get_all()
+        self.assertEqual(result, expected_result)
+
+    def test_run_get_by_id_or_name(self):
+        datacenter_1 = mock.Mock()
+        datacenter_1.__str__ = mock.Mock(return_value="''vim.Datacenter:1''")
+        datacenter_1_name_property = mock.PropertyMock(return_value='test_datacenter')
+        type(datacenter_1).name = datacenter_1_name_property
+        expected_configuration_1 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_1.configuration = expected_configuration_1
+        datacenter_1._moId = 1
+
+        datacenter_2 = mock.Mock()
+        datacenter_2.__str__ = mock.Mock(return_value="''vim.Datacenter:2''")
+        datacenter_2_name_property = mock.PropertyMock(return_value='test_datacenter_2')
+        type(datacenter_2).name = datacenter_2_name_property
+        expected_configuration_2 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_2.configuration = expected_configuration_2
+        datacenter_2._moId = 2
+
+        datacenter_3 = mock.Mock()
+        datacenter_3.__str__ = mock.Mock(return_value="''vim.Datacenter:3''")
+        datacenter_3_name_property = mock.PropertyMock(return_value='test_datacenter_3')
+        type(datacenter_3).name = datacenter_3_name_property
+        expected_configuration_3 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_3.configuration = expected_configuration_3
+        datacenter_3._moId = 3
+
+        datacenter_4 = mock.Mock()
+        datacenter_4.__str__ = mock.Mock(return_value="''vim.Datacenter:4''")
+        datacenter_4_name_property = mock.PropertyMock(return_value='test_datacenter_4')
+        type(datacenter_4).name = datacenter_4_name_property
+        expected_configuration_4 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_4.configuration = expected_configuration_4
+        datacenter_4._moId = 4
+
+        datacenter_5 = mock.Mock()
+        datacenter_5.__str__ = mock.Mock(return_value="''vim.Datacenter:5''")
+        datacenter_5_name_property = mock.PropertyMock(return_value='test_datacenter_5')
+        type(datacenter_5).name = datacenter_5_name_property
+        expected_configuration_5 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_5.configuration = expected_configuration_5
+        datacenter_5._moId = 5
+
+        mock_view = mock.Mock(view=[datacenter_1,
+                                    datacenter_2,
+                                    datacenter_3,
+                                    datacenter_4,
+                                    datacenter_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_datacenter_4',
+                'id': '4',
+                'configuration': expected_configuration_4
+            }, {
+                'name': 'test_datacenter_2',
+                'id': '2',
+                'configuration': expected_configuration_2
+            }, {
+                'name': 'test_datacenter_5',
+                'id': '5',
+                'configuration': expected_configuration_5
+            }
+        ]
+
+        result = self._action.run([4], ['test_datacenter_2', 'test_datacenter_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_run_all(self):
+        datacenter_1 = mock.Mock()
+        datacenter_1.__str__ = mock.Mock(return_value="''vim.Datacenter:1''")
+        datacenter_1_name_property = mock.PropertyMock(return_value='test_datacenter')
+        type(datacenter_1).name = datacenter_1_name_property
+        expected_configuration_1 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_1.configuration = expected_configuration_1
+        datacenter_1._moId = 1
+
+        datacenter_2 = mock.Mock()
+        datacenter_2.__str__ = mock.Mock(return_value="''vim.Datacenter:2''")
+        datacenter_2_name_property = mock.PropertyMock(return_value='test_datacenter_2')
+        type(datacenter_2).name = datacenter_2_name_property
+        expected_configuration_2 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_2.configuration = expected_configuration_2
+        datacenter_2._moId = 2
+
+        datacenter_3 = mock.Mock()
+        datacenter_3.__str__ = mock.Mock(return_value="''vim.Datacenter:3''")
+        datacenter_3_name_property = mock.PropertyMock(return_value='test_datacenter_3')
+        type(datacenter_3).name = datacenter_3_name_property
+        expected_configuration_3 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_3.configuration = expected_configuration_3
+        datacenter_3._moId = 3
+
+        datacenter_4 = mock.Mock()
+        datacenter_4.__str__ = mock.Mock(return_value="''vim.Datacenter:4''")
+        datacenter_4_name_property = mock.PropertyMock(return_value='test_datacenter_4')
+        type(datacenter_4).name = datacenter_4_name_property
+        expected_configuration_4 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_4.configuration = expected_configuration_4
+        datacenter_4._moId = 4
+
+        datacenter_5 = mock.Mock()
+        datacenter_5.__str__ = mock.Mock(return_value="''vim.Datacenter:5''")
+        datacenter_5_name_property = mock.PropertyMock(return_value='test_datacenter_5')
+        type(datacenter_5).name = datacenter_5_name_property
+        expected_configuration_5 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_5.configuration = expected_configuration_5
+        datacenter_5._moId = 5
+
+        mock_view = mock.Mock(view=[datacenter_1,
+                                    datacenter_2,
+                                    datacenter_3,
+                                    datacenter_4,
+                                    datacenter_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_datacenter',
+                'id': '1',
+                'configuration': expected_configuration_1
+            }, {
+                'name': 'test_datacenter_2',
+                'id': '2',
+                'configuration': expected_configuration_2
+            }, {
+                'name': 'test_datacenter_3',
+                'id': '3',
+                'configuration': expected_configuration_3
+            }, {
+                'name': 'test_datacenter_4',
+                'id': '4',
+                'configuration': expected_configuration_4
+            }, {
+                'name': 'test_datacenter_5',
+                'id': '5',
+                'configuration': expected_configuration_5
+            }
+        ]
+
+        result = self._action.run(None, None)
+        self.assertEqual(result, expected_result)

--- a/tests/test_action_datacenter_get.py
+++ b/tests/test_action_datacenter_get.py
@@ -110,17 +110,42 @@ class DatacenterGetTestCase(VsphereBaseActionTestCase):
                 'id': '4',
                 'configuration': expected_configuration_4
             }, {
-                'name': 'test_datacenter_2',
-                'id': '2',
-                'configuration': expected_configuration_2
-            }, {
                 'name': 'test_datacenter_5',
                 'id': '5',
                 'configuration': expected_configuration_5
+            }, {
+                'name': 'test_datacenter_2',
+                'id': '2',
+                'configuration': expected_configuration_2
             }
         ]
 
         result = self._action.get_by_id_or_name([4], ['test_datacenter_2', 'test_datacenter_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name_duplicate(self):
+        datacenter_1 = mock.Mock()
+        datacenter_1.__str__ = mock.Mock(return_value="''vim.Datacenter:1''")
+        datacenter_1_name_property = mock.PropertyMock(return_value='test_datacenter')
+        type(datacenter_1).name = datacenter_1_name_property
+        expected_configuration_1 = {'defaultHardwareVersionKey': 'test'}
+        datacenter_1.configuration = expected_configuration_1
+        datacenter_1._moId = 1
+
+        mock_view = mock.Mock(view=[datacenter_1])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_datacenter',
+                'id': '1',
+                'configuration': expected_configuration_1
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([1], ['test_datacenter'])
         self.assertEqual(result, expected_result)
 
     def test_get_all_datacenters(self):
@@ -216,13 +241,13 @@ class DatacenterGetTestCase(VsphereBaseActionTestCase):
                 'id': '4',
                 'configuration': expected_configuration_4
             }, {
-                'name': 'test_datacenter_2',
-                'id': '2',
-                'configuration': expected_configuration_2
-            }, {
                 'name': 'test_datacenter_5',
                 'id': '5',
                 'configuration': expected_configuration_5
+            }, {
+                'name': 'test_datacenter_2',
+                'id': '2',
+                'configuration': expected_configuration_2
             }
         ]
 

--- a/tests/test_action_datastore_get.py
+++ b/tests/test_action_datastore_get.py
@@ -124,6 +124,10 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
 
         expected_result = [
             {
+                'name': 'test_datastore_5',
+                'id': 5,
+                'summary': expected_sumary_5
+            }, {
                 'name': 'test_datastore_4',
                 'id': 4,
                 'summary': expected_sumary_4
@@ -131,14 +135,38 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
                 'name': 'test_datastore_2',
                 'id': 2,
                 'summary': expected_sumary_2
-            }, {
-                'name': 'test_datastore_5',
-                'id': 5,
-                'summary': expected_sumary_5
             }
         ]
 
         result = self._action.get_by_id_or_name([4], ['test_datastore_2', 'test_datastore_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name_duplicate(self):
+        datastore_1 = mock.Mock()
+        datastore_1_name_property = mock.PropertyMock(return_value='test_datastore')
+        type(datastore_1).name = datastore_1_name_property
+        expected_sumary_1 = {
+            'datastore': {
+                '_moId': 1
+            }
+        }
+        datastore_1.summary = expected_sumary_1
+        datastore_1._moId = 1
+
+        mock_view = mock.Mock(view=[datastore_1])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_datastore',
+                'id': 1,
+                'summary': expected_sumary_1
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([1], ['test_datastore'])
         self.assertEqual(result, expected_result)
 
     def test_get_all_datastores(self):
@@ -251,6 +279,10 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
 
         expected_result = [
             {
+                'name': 'test_datastore_5',
+                'id': 5,
+                'summary': expected_sumary_5
+            }, {
                 'name': 'test_datastore_4',
                 'id': 4,
                 'summary': expected_sumary_4
@@ -258,10 +290,6 @@ class DatastoreGetTestCase(VsphereBaseActionTestCase):
                 'name': 'test_datastore_2',
                 'id': 2,
                 'summary': expected_sumary_2
-            }, {
-                'name': 'test_datastore_5',
-                'id': 5,
-                'summary': expected_sumary_5
             }
         ]
 

--- a/tests/test_action_get_tags_from_objects.py
+++ b/tests/test_action_get_tags_from_objects.py
@@ -65,9 +65,9 @@ class GetTagsFromObjectsTestCase(VsphereBaseActionTestCase):
         ]
 
         expected_result = {
-            'test_category_1': 'test_tag_1',
-            'test_category_2': 'test_tag_2',
-            'test_category_3': 'test_tag_3',
+            'test_category_1': ['test_tag_1'],
+            'test_category_2': ['test_tag_2'],
+            'test_category_3': ['test_tag_3'],
         }
 
         # invoke action with valid parameters
@@ -124,9 +124,9 @@ class GetTagsFromObjectsTestCase(VsphereBaseActionTestCase):
 
         expected_result = {
             'vm-123': {
-                'test_category_1': 'test_tag_1',
-                'test_category_2': 'test_tag_2',
-                'test_category_3': 'test_tag_3',
+                'test_category_1': ['test_tag_1'],
+                'test_category_2': ['test_tag_2'],
+                'test_category_3': ['test_tag_3'],
             }
         }
 

--- a/tests/test_action_network_get.py
+++ b/tests/test_action_network_get.py
@@ -131,19 +131,48 @@ class NetworkGetTestCase(VsphereBaseActionTestCase):
                 'is_dvs': False,
                 'summary': expected_sumary_4
             }, {
-                'name': 'test_network_2',
-                'id': 2,
-                'is_dvs': False,
-                'summary': expected_sumary_2
-            }, {
                 'name': 'test_network_5',
                 'id': 5,
                 'is_dvs': True,
                 'summary': expected_sumary_5
+            }, {
+                'name': 'test_network_2',
+                'id': 2,
+                'is_dvs': False,
+                'summary': expected_sumary_2
             }
         ]
 
         result = self._action.get_by_id_or_name([4], ['test_network_2', 'test_network_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name_duplicate(self):
+        network_1 = mock.Mock()
+        network_1_name_property = mock.PropertyMock(return_value='test_network')
+        type(network_1).name = network_1_name_property
+        expected_sumary_1 = {
+            'network': {
+                '_moId': 1
+            }
+        }
+        network_1.summary = expected_sumary_1
+        network_1._moId = 1
+
+        mock_view = mock.Mock(view=[network_1])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_network',
+                'id': 1,
+                'is_dvs': False,
+                'summary': expected_sumary_1
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([1], ['test_network'])
         self.assertEqual(result, expected_result)
 
     def test_get_all_networks(self):
@@ -236,7 +265,7 @@ class NetworkGetTestCase(VsphereBaseActionTestCase):
         network_4.summary = expected_sumary_4
         network_4._moId = 4
 
-        network_5 = mock.Mock()
+        network_5 = mock.Mock(spec=vim.dvs.DistributedVirtualPortgroup)
         network_5_name_property = mock.PropertyMock(return_value='test_network_5')
         type(network_5).name = network_5_name_property
         expected_sumary_5 = {
@@ -263,15 +292,15 @@ class NetworkGetTestCase(VsphereBaseActionTestCase):
                 'is_dvs': False,
                 'summary': expected_sumary_4
             }, {
+                'name': 'test_network_5',
+                'id': 5,
+                'is_dvs': True,
+                'summary': expected_sumary_5
+            }, {
                 'name': 'test_network_2',
                 'id': 2,
                 'is_dvs': False,
                 'summary': expected_sumary_2
-            }, {
-                'name': 'test_network_5',
-                'id': 5,
-                'is_dvs': False,
-                'summary': expected_sumary_5
             }
         ]
 

--- a/tests/test_action_template_get.py
+++ b/tests/test_action_template_get.py
@@ -1,0 +1,361 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+# from vmwarelib import inventory
+from template_get import TemplateGet
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'TemplateGet'
+]
+
+
+class TemplateGetTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = TemplateGet
+
+    def setUp(self):
+        super(TemplateGetTestCase, self).setUp()
+
+        self._action = self.get_action_instance(self.new_config)
+
+        self._action.establish_connection = mock.Mock()
+        self._action.si_content = mock.Mock()
+
+    def test_get_template_dict(self):
+        template_1 = mock.Mock()
+        template_1_name_property = mock.PropertyMock(return_value='test_template')
+        type(template_1).name = template_1_name_property
+        expected_sumary = {
+            'vm': {
+                '_moId': 1
+            }
+        }
+        template_1.summary = expected_sumary
+        template_1._moId = 1
+
+        expected_result = {
+            'name': 'test_template',
+            'id': 1,
+            'summary': expected_sumary
+        }
+
+        result = self._action.get_template_dict(template_1)
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name(self):
+        template_1 = mock.Mock()
+        template_1_name_property = mock.PropertyMock(return_value='test_template')
+        type(template_1).name = template_1_name_property
+        expected_sumary_1 = {
+            'vm': {
+                '_moId': 1
+            }
+        }
+        template_1.summary = expected_sumary_1
+        template_1._moId = 1
+
+        template_2 = mock.Mock()
+        template_2_name_property = mock.PropertyMock(return_value='test_template_2')
+        type(template_2).name = template_2_name_property
+        expected_sumary_2 = {
+            'vm': {
+                '_moId': 2
+            }
+        }
+        template_2.summary = expected_sumary_2
+        template_2._moId = 2
+
+        template_3 = mock.Mock()
+        template_3_name_property = mock.PropertyMock(return_value='test_template_3')
+        type(template_3).name = template_3_name_property
+        expected_sumary_3 = {
+            'vm': {
+                '_moId': 3
+            }
+        }
+        template_3.summary = expected_sumary_3
+        template_3._moId = 3
+
+        template_4 = mock.Mock()
+        template_4_name_property = mock.PropertyMock(return_value='test_template_4')
+        type(template_4).name = template_4_name_property
+        expected_sumary_4 = {
+            'vm': {
+                '_moId': 4
+            }
+        }
+        template_4.summary = expected_sumary_4
+        template_4._moId = 4
+
+        template_5 = mock.Mock()
+        template_5_name_property = mock.PropertyMock(return_value='test_template_5')
+        type(template_5).name = template_5_name_property
+        expected_sumary_5 = {
+            'vm': {
+                '_moId': 5
+            }
+        }
+        template_5.summary = expected_sumary_5
+        template_5._moId = 5
+
+        mock_view = mock.Mock(view=[template_1,
+                                    template_2,
+                                    template_3,
+                                    template_4,
+                                    template_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_template_4',
+                'id': 4,
+                'summary': expected_sumary_4
+            }, {
+                'name': 'test_template_2',
+                'id': 2,
+                'summary': expected_sumary_2
+            }, {
+                'name': 'test_template_5',
+                'id': 5,
+                'summary': expected_sumary_5
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([4], ['test_template_2', 'test_template_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_all_templates(self):
+        template_1 = mock.Mock()
+        template_1_name_property = mock.PropertyMock(return_value='test_template')
+        type(template_1).name = template_1_name_property
+        expected_sumary_1 = {
+            'vm': {
+                '_moId': 1
+            }
+        }
+        template_1.summary = expected_sumary_1
+        template_1._moId = 1
+
+        template_2 = mock.Mock()
+        template_2_name_property = mock.PropertyMock(return_value='test_template_2')
+        type(template_2).name = template_2_name_property
+        expected_sumary_2 = {
+            'vm': {
+                '_moId': 2
+            }
+        }
+        template_2.summary = expected_sumary_2
+        template_2._moId = 2
+
+        mock_view = mock.Mock(view=[template_1, template_2])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_template',
+                'id': 1,
+                'summary': expected_sumary_1
+            }, {
+                'name': 'test_template_2',
+                'id': 2,
+                'summary': expected_sumary_2
+            }
+        ]
+
+        result = self._action.get_all()
+        self.assertEqual(result, expected_result)
+
+    def test_run_get_by_id_or_name(self):
+        template_1 = mock.Mock()
+        template_1_name_property = mock.PropertyMock(return_value='test_template')
+        type(template_1).name = template_1_name_property
+        expected_sumary_1 = {
+            'vm': {
+                '_moId': 1
+            }
+        }
+        template_1.summary = expected_sumary_1
+        template_1._moId = 1
+
+        template_2 = mock.Mock()
+        template_2_name_property = mock.PropertyMock(return_value='test_template_2')
+        type(template_2).name = template_2_name_property
+        expected_sumary_2 = {
+            'vm': {
+                '_moId': 2
+            }
+        }
+        template_2.summary = expected_sumary_2
+        template_2._moId = 2
+
+        template_3 = mock.Mock()
+        template_3_name_property = mock.PropertyMock(return_value='test_template_3')
+        type(template_3).name = template_3_name_property
+        expected_sumary_3 = {
+            'vm': {
+                '_moId': 3
+            }
+        }
+        template_3.summary = expected_sumary_3
+        template_3._moId = 3
+
+        template_4 = mock.Mock()
+        template_4_name_property = mock.PropertyMock(return_value='test_template_4')
+        type(template_4).name = template_4_name_property
+        expected_sumary_4 = {
+            'vm': {
+                '_moId': 4
+            }
+        }
+        template_4.summary = expected_sumary_4
+        template_4._moId = 4
+
+        template_5 = mock.Mock()
+        template_5_name_property = mock.PropertyMock(return_value='test_template_5')
+        type(template_5).name = template_5_name_property
+        expected_sumary_5 = {
+            'vm': {
+                '_moId': 5
+            }
+        }
+        template_5.summary = expected_sumary_5
+        template_5._moId = 5
+
+        mock_view = mock.Mock(view=[template_1,
+                                    template_2,
+                                    template_3,
+                                    template_4,
+                                    template_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_template_4',
+                'id': 4,
+                'summary': expected_sumary_4
+            }, {
+                'name': 'test_template_2',
+                'id': 2,
+                'summary': expected_sumary_2
+            }, {
+                'name': 'test_template_5',
+                'id': 5,
+                'summary': expected_sumary_5
+            }
+        ]
+
+        result = self._action.run([4], ['test_template_2', 'test_template_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_run_all(self):
+        template_1 = mock.Mock()
+        template_1_name_property = mock.PropertyMock(return_value='test_template')
+        type(template_1).name = template_1_name_property
+        expected_sumary_1 = {
+            'vm': {
+                '_moId': 1
+            }
+        }
+        template_1.summary = expected_sumary_1
+        template_1._moId = 1
+
+        template_2 = mock.Mock()
+        template_2_name_property = mock.PropertyMock(return_value='test_template_2')
+        type(template_2).name = template_2_name_property
+        expected_sumary_2 = {
+            'vm': {
+                '_moId': 2
+            }
+        }
+        template_2.summary = expected_sumary_2
+        template_2._moId = 2
+
+        template_3 = mock.Mock()
+        template_3_name_property = mock.PropertyMock(return_value='test_template_3')
+        type(template_3).name = template_3_name_property
+        expected_sumary_3 = {
+            'vm': {
+                '_moId': 3
+            }
+        }
+        template_3.summary = expected_sumary_3
+        template_3._moId = 3
+
+        template_4 = mock.Mock()
+        template_4_name_property = mock.PropertyMock(return_value='test_template_4')
+        type(template_4).name = template_4_name_property
+        expected_sumary_4 = {
+            'vm': {
+                '_moId': 4
+            }
+        }
+        template_4.summary = expected_sumary_4
+        template_4._moId = 4
+
+        template_5 = mock.Mock()
+        template_5_name_property = mock.PropertyMock(return_value='test_template_5')
+        type(template_5).name = template_5_name_property
+        expected_sumary_5 = {
+            'vm': {
+                '_moId': 5
+            }
+        }
+        template_5.summary = expected_sumary_5
+        template_5._moId = 5
+
+        mock_view = mock.Mock(view=[template_1,
+                                    template_2,
+                                    template_3,
+                                    template_4,
+                                    template_5])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_template',
+                'id': 1,
+                'summary': expected_sumary_1
+            }, {
+                'name': 'test_template_2',
+                'id': 2,
+                'summary': expected_sumary_2
+            }, {
+                'name': 'test_template_3',
+                'id': 3,
+                'summary': expected_sumary_3
+            }, {
+                'name': 'test_template_4',
+                'id': 4,
+                'summary': expected_sumary_4
+            }, {
+                'name': 'test_template_5',
+                'id': 5,
+                'summary': expected_sumary_5
+            }
+        ]
+
+        result = self._action.run(None, None)
+        self.assertEqual(result, expected_result)

--- a/tests/test_action_template_get.py
+++ b/tests/test_action_template_get.py
@@ -124,6 +124,10 @@ class TemplateGetTestCase(VsphereBaseActionTestCase):
 
         expected_result = [
             {
+                'name': 'test_template_5',
+                'id': 5,
+                'summary': expected_sumary_5
+            }, {
                 'name': 'test_template_4',
                 'id': 4,
                 'summary': expected_sumary_4
@@ -131,14 +135,38 @@ class TemplateGetTestCase(VsphereBaseActionTestCase):
                 'name': 'test_template_2',
                 'id': 2,
                 'summary': expected_sumary_2
-            }, {
-                'name': 'test_template_5',
-                'id': 5,
-                'summary': expected_sumary_5
             }
         ]
 
         result = self._action.get_by_id_or_name([4], ['test_template_2', 'test_template_5'])
+        self.assertEqual(result, expected_result)
+
+    def test_get_by_id_or_name_duplicate(self):
+        template_1 = mock.Mock()
+        template_1_name_property = mock.PropertyMock(return_value='test_template')
+        type(template_1).name = template_1_name_property
+        expected_sumary_1 = {
+            'vm': {
+                '_moId': 1
+            }
+        }
+        template_1.summary = expected_sumary_1
+        template_1._moId = 1
+
+        mock_view = mock.Mock(view=[template_1])
+        mock_vmware = mock.Mock(rootFolder="folder")
+        mock_vmware.viewManager.CreateContainerView.return_value = mock_view
+        self._action.si_content = mock_vmware
+
+        expected_result = [
+            {
+                'name': 'test_template',
+                'id': 1,
+                'summary': expected_sumary_1
+            }
+        ]
+
+        result = self._action.get_by_id_or_name([1], ['test_template'])
         self.assertEqual(result, expected_result)
 
     def test_get_all_templates(self):
@@ -251,6 +279,10 @@ class TemplateGetTestCase(VsphereBaseActionTestCase):
 
         expected_result = [
             {
+                'name': 'test_template_5',
+                'id': 5,
+                'summary': expected_sumary_5
+            }, {
                 'name': 'test_template_4',
                 'id': 4,
                 'summary': expected_sumary_4
@@ -258,10 +290,6 @@ class TemplateGetTestCase(VsphereBaseActionTestCase):
                 'name': 'test_template_2',
                 'id': 2,
                 'summary': expected_sumary_2
-            }, {
-                'name': 'test_template_5',
-                'id': 5,
-                'summary': expected_sumary_5
             }
         ]
 


### PR DESCRIPTION
Added actions to get datacenter, cluster, and templates from vsphere. Corrected issues so that a name or id can be passed in while leaving the other one blank. Added all necessary tests. Fixed issue with getting tags from objects where categories that can have multiple values were only displaying the last value retrieved. 