### PR TITLE
Added lots of new features to the backend tagging interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Continuous Integration testing
+ci/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Additions:
 * Added lots of new back-end API functionality to the `vmwarelib.tagging.VmwareTagging` interface.
 * Added new `vsphere.tag_attach_bulk` action to attach a tag to a bulk set of resources.
   Primary usecase is tagging all VMs in a cluster dynamically.
+* Added new `vsphere.tag_detach_bulk` action to detach a tag from a bulk set of resources.
+  Primary usecase is remoave a tag from all VMs in a cluster dynamically.
 
 Contributed by Nick Maludy (@nmaludy Encore Technologies).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 Additions:
 * Added lots of new back-end API functionality to the `vmwarelib.tagging.VmwareTagging` interface.
-
+* Added new `vsphere.tag_attach_bulk` action to attach a tag to a bulk set of resources.
+  Primary usecase is tagging all VMs in a cluster dynamically.
 
 Contributed by Nick Maludy (@nmaludy Encore Technologies).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.16.0
+
+Additions:
+* Added lots of new back-end API functionality to the `vmwarelib.tagging.VmwareTagging` interface.
+
+
+Contributed by Nick Maludy (@nmaludy Encore Technologies).
+
 ## v0.15.1
 
 Changed action:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+THIS_FILE := $(lastword $(MAKEFILE_LIST))
+ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+CI_REPO_PATH ?= $(ROOT_DIR)/ci
+CI_REPO_BRANCH ?= master
+
+# read in pack's name from pack.yaml, export it so that the ci/Makefile
+# can access its value
+export PACK_NAME := $(shell grep "name:" pack.yaml | awk '{ print $$2 }')
+
+.PHONY: all
+all: .DEFAULT
+
+.PHONY: clean
+clean: clean-ci-repo
+
+.PHONY: pack-name
+pack-name: .pack-name
+
+.PHONY: .pack-name
+.pack-name:
+	@echo $(PACK_NAME)
+
+# Clone the ci-repo into the ci/ directory
+.PHONY: clone-ci-repo
+clone-ci-repo:
+	@echo
+	@echo "==================== clone-ci-repo ===================="
+	@echo
+	@if [ ! -d "$(CI_REPO_PATH)" ]; then \
+		git clone https://github.com/EncoreTechnologies/ci-stackstorm.git --depth 1 --single-branch --branch $(CI_REPO_BRANCH) $(CI_REPO_PATH); \
+	else \
+		pushd $(CI_REPO_PATH) &> /dev/null; \
+		git pull; \
+		popd &> /dev/null; \
+	fi;
+
+# Clean the ci-repo (calling `make clean` in that directory), then remove the
+# ci-repo directory
+.PHONY: clean-ci-repo
+clean-ci-repo:
+	@echo
+	@echo "==================== clean-ci-repo ===================="
+	@echo
+	@if [ -d "$(CI_REPO_PATH)" ]; then \
+		make -f $(ROOT_DIR)/ci/Makefile clean; \
+	fi;
+	rm -rf $(CI_REPO_PATH)
+
+# forward all make targets not found in this makefile to the ci makefile to do
+# the actual work (by calling the invoke-ci-makefile target)
+# http://stackoverflow.org/wiki/Last-Resort_Makefile_Targets
+# Unfortunately the .DEFAULT target doesn't allow for dependencies
+# so we have to manually specify all of the steps in this target.
+.DEFAULT: 
+	$(MAKE) clone-ci-repo
+	@echo
+	@echo "==================== invoke ci/Makefile (targets: $(MAKECMDGOALS)) ===================="
+	@echo
+	make -f $(ROOT_DIR)/ci/Makefile $(MAKECMDGOALS)

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ PYVMOMI 6.0 requires alternative connection coding and Python 2.7.9 minimum due 
 |  host_network_hits_get  |  Retrieve Network Hints for given Hosts (ESXi)  |
 |  set_vm  |  Changes configuration of a Virtual Machine.  |
 |  tag_attach_or_create  |  Attach a tag to a given object and create the tag and category if they don't exist  |
+|  tag_attach_bulk | Query a parent object and "bulk" tag all of the children under that parent. |
 |  tag_category_create  |  Create a vsphere tag category  |
 |  tag_category_delete  |  Delete a tag category from vSphere  |
 |  tag_category_list  |  List all tag categories from vsphere  |

--- a/actions/tag_attach_bulk.py
+++ b/actions/tag_attach_bulk.py
@@ -1,0 +1,43 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vmwarelib.actions import BaseAction
+
+
+class TagAttachBulk(BaseAction):
+    def run(self, bulk_object_type,
+            category_name, category_description, category_cardinality, category_types,
+            query_object_type, query_object_name,
+            replace,
+            tag_name, tag_description,
+            vsphere):
+        self.connect_rest(vsphere)
+
+        # create the category and tags
+        category = self.tagging.category_get_or_create(category_name,
+                                                       category_description,
+                                                       category_cardinality,
+                                                       category_types)
+        self.tagging.tag_get_or_create(tag_name, category["id"], tag_description)
+
+        # either add to the existing tags in the category or replace all tags
+        # of this category with the new tag
+        action = 'replace' if replace else 'add'
+        return self.tagging.tag_bulk(query_object_type=query_object_type,
+                                     query_object_name=query_object_name,
+                                     bulk_object_type=bulk_object_type,
+                                     category=category_name,
+                                     tag=tag_name,
+                                     cardinality=category_cardinality,
+                                     action=action)

--- a/actions/tag_attach_bulk.yaml
+++ b/actions/tag_attach_bulk.yaml
@@ -1,0 +1,156 @@
+---
+name: tag_attach_bulk
+runner_type: python-script
+description: >
+  Query a parent object and "bulk" tag all of the children under that parent.
+  This will create the category and tag if they do not exist.
+
+  To bulk tag all of the VMs under a Cluster the invocation would look like:
+    st2 run vsphere.tag_bulk_attach \
+        category_name="automation_friendly"\
+        tag_name="true"\
+        query_object_name="cluster.dev1"\
+        query_object_type="ClusterComputeResource"\
+        bulk_object_type="VirtualMachine"
+
+  This would query the cluster (ClusterComputeResource) named "cluster.dev1" for
+  all VMs (VirtualMachine) that are a member of that cluster. It would then tag
+  all of these VMs with automation_friendly=true.
+enabled: true
+entry_point: tag_attach_bulk.py
+parameters:
+    bulk_object_type:
+        type: 'string'
+        description: Type of object to attach tag to (e.g. VirtualMachine)
+        required: true
+        enum:
+          - AuthorizationManager
+          - ClusterComputeResource
+          - ComputeResource
+          - CustomFieldsManager
+          - Datacenter
+          - Datastore
+          - DiagnosticManager
+          - DistributedVirtualSwitch
+          - DistributedVirtualPortgroup
+          - DrsStatsManager/InjectorWorkload
+          - Extension
+          - ExtensionManager
+          - HbrManager
+          - HostSystem
+          - HttpNfcLease
+          - IpPoolManager
+          - LatencySensitivity
+          - LicenseAssignmentManager
+          - LicenseManager
+          - LocalizationManager
+          - ManagedEntity
+          - Network
+          - OpaqueNetwork
+          - OvfConsumer
+          - OvfManager
+          - PerformanceManager
+          - ResourcePlanningManager
+          - ResourcePool
+          - ServiceInstance
+          - ServiceManager
+          - SessionManager
+          - SharesInfo
+          - SimpleCommand
+          - StoragePod
+          - StorageResourceManager
+          - TaskFilterSpec
+          - TaskInfo
+          - UpdateVirtualMachineFilesResult
+          - VirtualApp
+          - VirtualDiskManager
+          - VirtualMachine
+    category_cardinality:
+        type: 'string'
+        description: Cardinality of the tag category, only used if category needs to be created
+        required: false
+        default: 'SINGLE'
+        enum:
+          - 'SINGLE'
+          - 'MULTIPLE'
+    category_description:
+        type: 'string'
+        description: Description of the tag category, only used if category needs to be created
+        required: false
+    category_name:
+        type: 'string'
+        description: Category name of the tag to attach
+        required: true
+    category_types:
+        type: 'array'
+        description: Associable types for the tag category, only used if category needs to be created (Empty array means all types)
+        required: false
+        default: []
+    query_name:
+        type: 'string'
+        description: ID of the object to attach tag to
+        required: true
+    query_object_type:
+        type: 'string'
+        description: Type of object to query for sub-objects (e.g. ClusterComputeResource)
+        required: true
+        enum:
+          - AuthorizationManager
+          - ClusterComputeResource
+          - ComputeResource
+          - CustomFieldsManager
+          - Datacenter
+          - Datastore
+          - DiagnosticManager
+          - DistributedVirtualSwitch
+          - DistributedVirtualPortgroup
+          - DrsStatsManager/InjectorWorkload
+          - Extension
+          - ExtensionManager
+          - HbrManager
+          - HostSystem
+          - HttpNfcLease
+          - IpPoolManager
+          - LatencySensitivity
+          - LicenseAssignmentManager
+          - LicenseManager
+          - LocalizationManager
+          - ManagedEntity
+          - Network
+          - OpaqueNetwork
+          - OvfConsumer
+          - OvfManager
+          - PerformanceManager
+          - ResourcePlanningManager
+          - ResourcePool
+          - ServiceInstance
+          - ServiceManager
+          - SessionManager
+          - SharesInfo
+          - SimpleCommand
+          - StoragePod
+          - StorageResourceManager
+          - TaskFilterSpec
+          - TaskInfo
+          - UpdateVirtualMachineFilesResult
+          - VirtualApp
+          - VirtualDiskManager
+          - VirtualMachine
+    replace:
+        type: 'boolean'
+        description: Remove all tags with the given category before assigning the new one
+        required: false
+        default: true
+    tag_description:
+        type: 'string'
+        description: Description of the tag, only used if tag needs to be created
+        required: false
+    tag_name:
+        type: 'string'
+        description: Name of the tag to attach
+        required: true
+    vsphere:
+        type: "string"
+        description: Pre-Configured vsphere connection details
+        required: false
+        default: ~

--- a/actions/tag_detach_bulk.py
+++ b/actions/tag_detach_bulk.py
@@ -15,29 +15,27 @@
 from vmwarelib.actions import BaseAction
 
 
-class TagAttachBulk(BaseAction):
+class TagDetachBulk(BaseAction):
     def run(self, bulk_object_type,
-            category_name, category_description, category_cardinality, category_types,
+            category_name, category_cardinality,
             query_object_type, query_object_name,
-            replace,
-            tag_name, tag_description,
+            tag_name,
             vsphere):
         self.connect_rest(vsphere)
 
         # create the category and tags
-        category = self.tagging.category_get_or_create(category_name,
-                                                       category_description,
-                                                       category_cardinality,
-                                                       category_types)
-        self.tagging.tag_get_or_create(tag_name, category["id"], tag_description)
+        category = self.tagging.category_find_by_name(category_name)
+        if not category:
+            return "Category doesn't exist: category={}".format(category_name)
 
-        # either add to the existing tags in the category or replace all tags
-        # of this category with the new tag
-        action = 'replace' if replace else 'attach'
+        tag = self.tagging.tag_find_by_name(tag_name, category['id'])
+        if not tag:
+            return "Tag doesn't exist: category={} tag={}".format(category_name, tag_name)
+
         return self.tagging.tag_bulk(query_object_type=query_object_type,
                                      query_object_name=query_object_name,
                                      bulk_object_type=bulk_object_type,
                                      category=category_name,
                                      tag=tag_name,
                                      cardinality=category_cardinality,
-                                     action=action)
+                                     action='detach')

--- a/actions/tag_detach_bulk.yaml
+++ b/actions/tag_detach_bulk.yaml
@@ -1,12 +1,12 @@
 ---
-name: tag_attach_bulk
+name: tag_detach_bulk
 runner_type: python-script
 description: >
-  Query a parent object and "bulk" tag all of the children under that parent.
-  This will create the category and tag if they do not exist.
+  Query a parent object and "bulk" remove tags for all of the children under that parent.
+  If the category and tag do not exist, this will simply return without doing any work.
 
   To bulk tag all of the VMs under a Cluster the invocation would look like:
-    st2 run vsphere.tag_attach_bulk \
+    st2 run vsphere.tag_detach_bulk \
         category_name="automation_friendly"\
         tag_name="true"\
         query_object_name="cluster.dev1"\
@@ -17,11 +17,11 @@ description: >
   all VMs (VirtualMachine) that are a member of that cluster. It would then tag
   all of these VMs with automation_friendly=true.
 enabled: true
-entry_point: tag_attach_bulk.py
+entry_point: tag_detach_bulk.py
 parameters:
     bulk_object_type:
         type: 'string'
-        description: Type of object to attach tag to (e.g. VirtualMachine)
+        description: Type of object to detach tags from (e.g. VirtualMachine)
         required: true
         enum:
           - AuthorizationManager
@@ -73,22 +73,13 @@ parameters:
         enum:
           - 'SINGLE'
           - 'MULTIPLE'
-    category_description:
-        type: 'string'
-        description: Description of the tag category, only used if category needs to be created
-        required: false
     category_name:
         type: 'string'
-        description: Category name of the tag to attach
+        description: Category name of the tag to detach
         required: true
-    category_types:
-        type: 'array'
-        description: Associable types for the tag category, only used if category needs to be created (Empty array means all types)
-        required: false
-        default: []
     query_object_name:
         type: 'string'
-        description: ID of the object to attach tag to
+        description: ID of the object to detach tags from
         required: true
     query_object_type:
         type: 'string'
@@ -136,18 +127,9 @@ parameters:
           - VirtualApp
           - VirtualDiskManager
           - VirtualMachine
-    replace:
-        type: 'boolean'
-        description: Remove all tags with the given category before assigning the new one
-        required: false
-        default: true
-    tag_description:
-        type: 'string'
-        description: Description of the tag, only used if tag needs to be created
-        required: false
     tag_name:
         type: 'string'
-        description: Name of the tag to attach
+        description: Name of the tag to detach
         required: true
     vsphere:
         type: "string"

--- a/actions/vmwarelib/tagging.py
+++ b/actions/vmwarelib/tagging.py
@@ -12,14 +12,82 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
+import requests
+
+try:
+    import urllib3
+    urllib3.disable_warnings()
+except ImportError:
+    pass
+
+# https://vdc-repo.vmware.com/vmwb-repository/dcr-public/1cd28284-3b72-4885-9e31-d1c6d9e26686/71ef7304-a6c9-43b3-a3cd-868b2c236c81/doc/operations/com/vmware/cis/tagging/category.create-operation.html
+VMWARE_CARDINALITY = [
+    "SINGLE",
+    "MULTIPLE",
+]
+
+# vSphere Web Services API
+# https://code.vmware.com/doc/preview?id=4206#/doc/vmodl.ManagedObjectReference.html
+VMWARE_OBJECT_TYPES = [
+    'ClusterComputeResource',
+    'Datacenter',
+    'Datastore',
+    'DistributedVirtualPortgroup',
+    'DistributedVirtualSwitch',
+    'Folder',
+    'HostNetwork',
+    'HostSystem',
+    # 'Library',     # Content Library, REST API is a PITA
+    # 'LibraryItem', # Content Library item, REST API is a PITA
+    # 'Network',   # duplicate of HostNetwork
+    'OpaqueNetwork',
+    'ResourcePool',
+    # 'StoragePod',  # Not sure what this is, REST API can't query for it
+    'VirtualApp',
+    'VirtualMachine',
+    # 'VmwareDistributedVirtualSwitch', # duplicate of DistributedVirtualSwitch
+]
+
+VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR = ("Sorry, VMware REST API doesn't support "
+                                        "querying for this type of object")
+
+VMWARE_QUERY_ERROR = "Unable to create a query based on a {} (not supported by VMware API)"
+
+ACTIONS = [
+    'add',
+    'remove',
+]
 
 
-class VmwareTagActions(object):
+class VmwareTagging(object):
     # vSphere Automation API (6.5)
     # API Reference: https://code.vmware.com/web/dp/explorer-apis?id=191
-    def __init__(self, session, url_base):
-        self.session = session
-        self.url_base = url_base
+    def __init__(self, server, username, password,
+                 scheme="https", port=None, ssl_verify=True, logger=None):
+        self.session = requests.Session()
+        self.session.verify = ssl_verify
+        self.session.auth = (username, password)
+        self.server = server
+        if port:
+            self.url_base = "{}://{}:{}".format(scheme, server, port)
+        else:
+            self.url_base = "{}://{}".format(scheme, server)
+
+        if logger:
+            # use provided logger
+            self.logger = logger
+        else:
+            # create logger from st2common
+            try:
+                from st2common.runners.utils import get_logger_for_python_runner_action
+                self.logger = get_logger_for_python_runner_action(
+                    action_name=self.__class__.__name__,
+                    log_level='debug')
+            except:
+                # otherwise create default logger
+                import logging
+                self.logger = logging.getLogger(__name__)
 
     ############################################################################
 
@@ -28,27 +96,38 @@ class VmwareTagActions(object):
     def make_url(self, endpoint):
         return self.url_base + endpoint
 
-    def get(self, endpoint):
+    def get(self, endpoint, params=None):
         url = self.make_url(endpoint)
-        response = self.session.get(url)
+        response = self.session.get(url, params=params)
         response.raise_for_status()
         return response.json()
 
-    def post(self, endpoint, payload=None):
+    def post(self, endpoint, payload=None, params=None):
         url = self.make_url(endpoint)
-        response = self.session.post(url, json=payload)
+        response = self.session.post(url, params=params, json=payload)
         response.raise_for_status()
         if response.text:
             return response.json()
         return None
 
-    def delete(self, endpoint, payload=None):
+    def delete(self, endpoint, payload=None, params=None):
         url = self.make_url(endpoint)
-        response = self.session.delete(url, json=payload)
+        response = self.session.delete(url, params=params, json=payload)
         response.raise_for_status()
         if response.text:
             return response.json()
         return None
+
+    ############################################################################
+
+    def login(self):
+        url = self.make_url("/rest/com/vmware/cis/session")
+        response = self.session.post(url)
+        response.raise_for_status()
+        # if this succeeds, the cookie is automatically saved in our session
+        # however, we'll return the cookie value so that it may be returned
+        # to the user
+        return dict(response.cookies)
 
     ############################################################################
 
@@ -78,18 +157,33 @@ class VmwareTagActions(object):
         return {"name": "",
                 "description": "",
                 "cardinality": "SINGLE",  # "SINGLE", "MULTIPLE"
-                "associable_types": ["VirtualMachine"]}  # One or more VMWARE_OBJECT_TYPES
+                "associable_types": []}  # One or more VMWARE_OBJECT_TYPES, none/[] = all types
 
     def category_create(self, name, description=None, cardinality=None,
                         associable_types=None):
+        print("Category create called")
         create_spec = self.category_create_spec()
         create_spec['name'] = name
         if description:
             create_spec['description'] = description
         if cardinality:
+            if cardinality not in VMWARE_CARDINALITY:
+                raise ValueError('Cardinality "{}" does not match the allowed choices: {}'
+                                 .format(cardinality, VMWARE_CARDINALITY))
             create_spec['cardinality'] = cardinality
-        if associable_types is not None:
+
+        # default to being able to tag all types
+        if associable_types is None or associable_types == []:
+            create_spec['associable_types'] = []
+        elif isinstance(associable_types, list):
+            for at in associable_types:
+                if at not in VMWARE_OBJECT_TYPES:
+                    raise ValueError('Object type "{}" does not match the allowed choices: {}'
+                                     .format(at, VMWARE_OBJECT_TYPES))
             create_spec['associable_types'] = associable_types
+        else:
+            raise ValueError('Object type must be a list, given: {}'
+                             .format(associable_types))
 
         response = self.post("/rest/com/vmware/cis/tagging/category",
                              payload={'create_spec': create_spec})
@@ -112,14 +206,17 @@ class VmwareTagActions(object):
     def tag_list(self, category_id=None):
         # Return all tags from the given category, or all tags from all categories
         if category_id:
-            response = self.post("/rest/com/vmware/cis/tagging/tag/id:{}?~action="
-                                 "list-tags-for-category".format(category_id))
+            return self.tag_list_for_category(category_id)
         else:
-            response = self.get("/rest/com/vmware/cis/tagging/tag")
-        return response["value"]
+            return self.get("/rest/com/vmware/cis/tagging/tag")['value']
 
     def tag_get(self, tag_id):
         response = self.get("/rest/com/vmware/cis/tagging/tag/id:{}".format(tag_id))
+        return response['value']
+
+    def tag_list_for_category(self, category_id):
+        url = ("/rest/com/vmware/cis/tagging/tag/id:{}".format(category_id))
+        response = self.post(url, params={'~action': 'list-tags-for-category'})
         return response['value']
 
     def tag_delete(self, tag_id):
@@ -161,42 +258,55 @@ class VmwareTagActions(object):
             tag = self.tag_get(created_tag_id)
         return tag
 
+    ##############################################################################
+
+    # creates a category and a tag all in one step
+    def category_tag_create(self, category, tag, cardinality, associable_types=None):
+        category = self.category_get_or_create(category,
+                                               cardinality=cardinality,
+                                               associable_types=associable_types)
+        tag = self.tag_get_or_create(tag, category["id"])
+        return (category, tag)
+
     ############################################################################
 
     # Tag Association Functions
 
-    def tag_association_endpoint(self, action, tag_id=None):
+    def tag_association_endpoint(self, tag_id=None):
         if tag_id:
-            return "/rest/com/vmware/cis/tagging/tag-association/id:{}?~action={}".format(tag_id,
-                                                                                          action)
+            return '/rest/com/vmware/cis/tagging/tag-association/id:{}'.format(tag_id)
         else:
-            return "/rest/com/vmware/cis/tagging/tag-association?~action={}".format(action)
+            return '/rest/com/vmware/cis/tagging/tag-association'
 
     def tag_association_attach(self, tag_id, obj_type, obj_id):
-        return self.post(self.tag_association_endpoint("attach", tag_id),
-                         payload={"object_id": {"id": obj_id,
-                                                "type": obj_type}})
+        return self.post(self.tag_association_endpoint(tag_id),
+                         params={'~action': 'attach'},
+                         payload={'object_id': {'id': obj_id,
+                                                'type': obj_type}})
 
     def tag_association_attach_multiple(self, tag_ids, obj_type, obj_id):
-        return self.post(self.tag_association_endpoint("attach-multiple-tags-to-object"),
-                         payload={"tag_ids": tag_ids,
-                                  "object_id": {"id": obj_id,
-                                                "type": obj_type}})
+        return self.post(self.tag_association_endpoint(),
+                         params={'~action': 'attach-multiple-tags-to-object'},
+                         payload={'tag_ids': tag_ids,
+                                  'object_id': {'id': obj_id,
+                                                'type': obj_type}})
 
     def tag_association_detach(self, tag_id, obj_type, obj_id):
-        return self.post(self.tag_association_endpoint("detach", tag_id),
-                         payload={"object_id": {"id": obj_id,
-                                                "type": obj_type}})
+        return self.post(self.tag_association_endpoint(tag_id),
+                         params={'~action': 'detach'},
+                         payload={'object_id': {'id': obj_id,
+                                                'type': obj_type}})
 
     def tag_association_list_attached_tags(self, obj_type, obj_id):
-        response = self.post(self.tag_association_endpoint("list-attached-tags"),
-                             payload={"object_id": {"id": obj_id,
-                                                    "type": obj_type}})
+        response = self.post(self.tag_association_endpoint(),
+                             params={'~action': 'list-attached-tags'},
+                             payload={'object_id': {'id': obj_id,
+                                                    'type': obj_type}})
         return response['value']
 
     def tag_association_list_attached_objects(self, tag_id):
-        response = self.post(self.tag_association_endpoint("list-attached-objects",
-                                                           tag_id))
+        response = self.post(self.tag_association_endpoint(tag_id),
+                             params={'~action': 'list-attached-objects'})
         return response['value']
 
     def tag_association_detach_category(self, category_id, obj_type, obj_id):
@@ -220,3 +330,415 @@ class VmwareTagActions(object):
 
         # attach the provided tag in this category to the object
         return self.tag_association_attach(tag_id, obj_type, obj_id)
+
+    def tag_association_action(self, category, tag, object_type, obj_id, action):
+        # action == 'add' or 'replace', one of ACTIONS
+        # tag the VM
+        if action == 'add':
+            self.tag_association_replace(tag['id'], object_type, obj_id)
+        else:
+            self.logger.debug("Detaching tag from object... category_id={} tag_id={}"
+                              " object_type={} object_id={}"
+                              .format(category['id'], tag['id'], object_type, obj_id))
+            self.tag_association_detach_category(category['id'], object_type, obj_id)
+
+    ############################################################################
+
+    def object_find_by_name(self, object_type, name):
+        self.logger.debug("Looking for object_type={} name={}".format(object_type, name))
+        params = {'filter.names.1': name}
+        object_list = self.object_find(object_type, params=params)
+        self.object_list_validate_single_element(object_list, object_type, params)
+        ids_list = self.object_list_extract_ids(object_list, object_type, params)
+        obj_id = ids_list[0]
+        self.logger.debug("Found object name={} as object_id={}".format(name, obj_id))
+        return obj_id
+
+    def object_list_validate_single_element(self, object_list, object_type, params):
+        if len(object_list) > 1:
+            filter_name, filter_value = self.filter_name_value(params)
+            raise ValueError(("Sorry, we found >1 object matching this name in vCenter: "
+                              "object_type={} {}={} objects={}").format(object_type,
+                                                                        filter_name,
+                                                                        filter_value,
+                                                                        object_list))
+
+    def object_list_extract_ids(self, object_list, object_type, params):
+        results = []
+        id_key = self.object_type_id_key(object_type)
+        for obj in object_list:
+            if id_key not in obj:
+                filter_name, filter_value = self.filter_name_value(params)
+                raise ValueError("Couldn't find the expected ID key in the returned object: "
+                                 "object_type={} {}={} id_key={} object={}".format(object_type,
+                                                                                   filter_name,
+                                                                                   filter_value,
+                                                                                   id_key,
+                                                                                   obj))
+            results.append(obj[id_key])
+
+        return results
+
+    def object_find(self, object_type, params):
+        if object_type not in VMWARE_OBJECT_TYPES:
+            raise ValueError('Object type "{}" does not match the allowed choices: {}'
+                             .format(object_type, VMWARE_OBJECT_TYPES))
+
+        if object_type == 'ClusterComputeResource':
+            return self.cluster_find(params=params)
+        elif object_type == 'Datacenter':
+            return self.datacenter_find(params=params)
+        elif object_type == 'Datastore':
+            return self.datastore_find(params=params)
+        elif object_type == 'DistributedVirtualPortgroup':
+            return self.distributedvirtualportgroup_find(params=params)
+        elif object_type == 'DistributedVirtualSwitch':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'Folder':
+            return self.folder_find(params=params)
+        elif object_type == 'HostNetwork':
+            return self.hostnetwork_find(params=params)
+        elif object_type == 'HostSystem':
+            return self.hostsystem_find(params=params)
+        elif object_type == 'Library':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'LibraryItem':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'OpaqueNetwork':
+            return self.opaquenetwork_find(params=params)
+        elif object_type == 'ResourcePool':
+            return self.resourcepool_find(params=params)
+        elif object_type == 'StoragePod':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'VirtualApp':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'VirtualMachine':
+            return self.vm_find(params=params)
+
+    def filter_name_value(self, params):
+        if len(params) == 1 and 'filter.names.1' in params:
+            return ('name', params['filter.names.1'])
+        else:
+            return ('filter', params)
+
+    def object_from_response(self, object_type, params, response, id_key):
+        if 'value' not in response:
+            raise ValueError("Response from VMware didn't contain the expected"
+                             " 'value' key: {}".format(response))
+
+        value = response['value']
+        if not isinstance(value, list):
+            raise ValueError("response['value'] is not a list, as expected,"
+                             " it is a type={} response={}"
+                             .format(type(response['value']),
+                                     response))
+
+        if len(value) == 0:
+            filter_name, filter_value = self.filter_name_value(params)
+            raise ValueError(("Sorry we couldn't find the object you asked for in vCenter: "
+                              "object_type={} {}={}").format(object_type,
+                                                             filter_name,
+                                                             filter_value))
+        return value
+
+    def cluster_find(self, params=None):
+        response = self.get("/rest/vcenter/cluster", params=params)
+        return self.object_from_response('ClusterComputeResoure', params, response, 'cluster')
+
+    def datacenter_find(self, params=None):
+        response = self.get("/rest/vcenter/datacenter", params=params)
+        return self.object_from_response('Datacenter', params, response, 'datacenter')
+
+    def datastore_find(self, params=None):
+        response = self.get("/rest/vcenter/datastore", params=params)
+        return self.object_from_response('Datastore', params, response, 'datastore')
+
+    def distributedvirtualportgroup_find(self, params=None):
+        params = params if params else {}
+        params['filter.types.1'] = 'DISTRIBUTED_PORTGROUP'
+        response = self.get("/rest/vcenter/network", params=params)
+        return self.object_from_response('DistributedVirtualPortgroup', params, response, 'network')
+
+    def folder_find(self, params=None):
+        response = self.get("/rest/vcenter/folder", params=params)
+        return self.object_from_response('Folder', params, response, 'folder')
+
+    def hostnetwork_find(self, params=None):
+        params = params if params else {}
+        params['filter.types.1'] = 'STANDARD_PORTGROUP'
+        response = self.get("/rest/vcenter/network", params=params)
+        return self.object_from_response('HostNetwork', params, response, 'network')
+
+    def hostsystem_find(self, params=None):
+        response = self.get("/rest/vcenter/host", params=params)
+        return self.object_from_response('HostSystem', params, response, 'host')
+
+    def opaquenetwork_find(self, params=None):
+        params = params if params else {}
+        params['filter.types.1'] = 'OPAQUE_NETWORK'
+        response = self.get("/rest/vcenter/network", params=params)
+        return self.object_from_response('OpaqueNetwork', params, response, 'network')
+
+    def resourcepool_find(self, params=None):
+        response = self.get("/rest/vcenter/resource-pool", params=params)
+        return self.object_from_response('ResourcePool', params, response, 'resource_pool')
+
+    def vm_find(self, params=None):
+        response = self.get("/rest/vcenter/vm", params=params)
+        return self.object_from_response('VirtualMachine', params, response, 'vm')
+
+    def object_type_id_key(self, object_type):
+        if object_type == 'ClusterComputeResource':
+            return 'cluster'
+        elif object_type == 'Datacenter':
+            return 'datacenter'
+        elif object_type == 'Datastore':
+            return 'datastore'
+        elif object_type == 'DistributedVirtualPortgroup':
+            return 'network'
+        elif object_type == 'DistributedVirtualSwitch':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'Folder':
+            return 'folder'
+        elif object_type == 'HostNetwork':
+            return 'network'
+        elif object_type == 'HostSystem':
+            return 'host'
+        elif object_type == 'Library':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'LibraryItem':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'OpaqueNetwork':
+            return 'network'
+        elif object_type == 'ResourcePool':
+            return 'resource_pool'
+        elif object_type == 'StoragePod':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'VirtualApp':
+            raise NotImplementedError(VMWARE_OBJECT_TYPE_UNSUPPORTED_ERROR)
+        elif object_type == 'VirtualMachine':
+            return 'vm'
+
+    def object_type_filter(self, object_type):
+        if object_type == 'ClusterComputeResource':
+            return 'filter.clusters'
+        elif object_type == 'Datacenter':
+            return 'filter.datacenters'
+        elif object_type == 'Datastore':
+            raise NotImplementedError()
+        elif object_type == 'DistributedVirtualPortgroup':
+            raise NotImplementedError(VMWARE_QUERY_ERROR.format('DistributedVirtualPortgroup'))
+        elif object_type == 'DistributedVirtualSwitch':
+            raise NotImplementedError(VMWARE_QUERY_ERROR.format('DistributedVirtualSwitch'))
+        elif object_type == 'Folder':
+            return 'filter.folders'
+        elif object_type == 'HostNetwork':
+            raise NotImplementedError(VMWARE_QUERY_ERROR.format('HostNetwork'))
+        elif object_type == 'HostSystem':
+            return 'filter.hosts'
+        elif object_type == 'Library':
+            raise NotImplementedError(VMWARE_QUERY_ERROR.format('Library'))
+        elif object_type == 'LibraryItem':
+            raise NotImplementedError(VMWARE_QUERY_ERROR.format('LibraryItem'))
+        elif object_type == 'OpaqueNetwork':
+            raise NotImplementedError(VMWARE_QUERY_ERROR.format('OpaqueNetwork'))
+        elif object_type == 'ResourcePool':
+            return 'filter.hosts'
+        elif object_type == 'StoragePod':
+            raise NotImplementedError(VMWARE_QUERY_ERROR.format('StoragePod'))
+        elif object_type == 'VirtualApp':
+            raise NotImplementedError(VMWARE_QUERY_ERROR.format('VirtualApp'))
+        elif object_type == 'VirtualMachine':
+            return 'filter.vms'
+
+    #######################################################################
+    def tag_single(self, object_type, object_name,
+                   category, tag, cardinality, action):
+        obj_id = self.object_find_by_name(object_type, object_name)
+
+        # create the category and tag
+        category, tag = self.category_tag_create(category, tag, cardinality)
+        # add the tag
+        self.tag_association_action(category, tag, object_type, obj_id, action)
+
+    def tag_bulk(self, query_object_type, query_name,
+                 object_type, object_name,
+                 bulk_object_type,
+                 category, tag, cardinality, action):
+        obj_id = self.object_find_by_name(query_object_type, query_name)
+
+        # create the category and tag
+        category, tag = self.category_tag_create(category, tag, cardinality)
+
+        # bulk find all of the objects
+        query_obj_type_filter = self.object_type_filter(query_object_type)
+        # make parameters look like: {'filter.cluster.1': 'domain-123'}
+        params = {query_obj_type_filter + '.1': obj_id}
+        object_list = self.object_find(bulk_object_type, params=params)
+        self.logger.debug(object_list)
+        ids_list = self.object_list_extract_ids(object_list, bulk_object_type, params)
+        self.logger.debug(ids_list)
+
+        # add the tags for all of the objects in the list
+        for obj_id in ids_list:
+            self.tag_association_action(category, tag, bulk_object_type, obj_id, action)
+
+
+############################################################################
+
+# RawDescriptionHelpFormatter - so that our epilog / examples render newlines properly
+# ArgumentDefaultsHelpFormatter - so help strings are show for the arguments
+class CliFormatter(argparse.RawDescriptionHelpFormatter,
+                   argparse.ArgumentDefaultsHelpFormatter):
+    pass
+
+
+class Cli(object):
+    def parse(self):
+        parser = argparse.ArgumentParser(
+            formatter_class=CliFormatter,
+            epilog=self.examples(),
+        )
+
+        subparsers = parser.add_subparsers(dest="command")
+
+        ##########################
+        # Single
+        single_parser = subparsers.add_parser('single',
+                                              help="Tags a single object (VM, Cluster, etc)",
+                                              formatter_class=CliFormatter,
+                                              epilog=self.examples_single())
+        single_parser.add_argument('-H', '--hostname', help='VMware vSphere hostname/IP')
+        single_parser.add_argument('-U', '--username', help='VMware vSphere username')
+        single_parser.add_argument('-P', '--password', help='VMware vSphere password')
+        single_parser.add_argument('-c', '--category',
+                                   help='Name of the tag category (key) to assign')
+        single_parser.add_argument('-t', '--tag',
+                                   help='Name of the tag (value) to assign')
+        single_parser.add_argument('--cardinality',
+                                   help=('How many tags of this category can exist on an'
+                                         ' object (one or many)'),
+                                   default='SINGLE',
+                                   choices=VMWARE_CARDINALITY)
+        single_parser.add_argument('-n', '--name',
+                                   help=('Name of the object in vSphere (example: VM name,'
+                                         ' cluster name, datastore name, etc)'))
+        single_parser.add_argument('-o', '--object-type',
+                                   help='Type of object to tag',
+                                   default='VirtualMachine',
+                                   choices=VMWARE_OBJECT_TYPES)
+        single_parser.add_argument('-a', '--action',
+                                   help='Action to perform on the tag',
+                                   default='add',
+                                   choices=ACTIONS)
+
+        ##########################
+        # Bulk
+        bulk_parser = subparsers.add_parser('bulk',
+                                            help="Bulk tags objects based on a query.",
+                                            # formatter_class=CliFormatter,
+                                            epilog=self.examples_bulk())
+        bulk_parser.add_argument('-H', '--hostname', help='VMware vSphere hostname/IP')
+        bulk_parser.add_argument('-U', '--username', help='VMware vSphere username')
+        bulk_parser.add_argument('-P', '--password', help='VMware vSphere password')
+        bulk_parser.add_argument('-c', '--category',
+                                 help='Name of the tag category (key) to assign')
+        bulk_parser.add_argument('-t', '--tag',
+                                 help='Name of the tag (value) to assign')
+        bulk_parser.add_argument('--cardinality',
+                                 help=('How many tags of this category can exist'
+                                       ' on an object (one or many)'),
+                                 default='SINGLE',
+                                 choices=VMWARE_CARDINALITY)
+        bulk_parser.add_argument('-a', '--action',
+                                 help='Action to perform on the tag',
+                                 default='add',
+                                 choices=ACTIONS)
+        bulk_parser.add_argument('--query-name',
+                                 help=('Name of the object in vSphere to query for'
+                                       ' bulk objects. (example: cluster name)'))
+        bulk_parser.add_argument('--query-object-type',
+                                 help='Type of object to query for sub-objects',
+                                 default='ClusterComputeResource',
+                                 choices=VMWARE_OBJECT_TYPES)
+        bulk_parser.add_argument('--bulk-object-type',
+                                 help='Type of object to tag "under" the query object',
+                                 default='VirtualMachine',
+                                 choices=VMWARE_OBJECT_TYPES)
+
+        return parser.parse_args()
+
+    def examples(self):
+        return self.examples_single() + self.examples_bulk()
+
+    def examples_single(self):
+        return (
+            "examples single:\n"
+            "  # Tag a VM with custom_thing = 'hello world'\n"
+            "  ./vphere_tagging_cmdb_exclude.py single"
+            " -H vsphere.domain.tld"
+            " -U username@domain.tld"
+            " -P password123"
+            " --name myvm.domain.tld"
+            " --category 'custom_thing'"
+            " --tag 'hello world'"
+            " --object-type VirtualMachine "
+            " --action add\n"
+            "\n"
+            "  # Tag a Cluster with custom_thing = 'hello world'\n"
+            "  ./vphere_tagging_cmdb_exclude.py single"
+            " -H vsphere.domain.tld"
+            " -U username@domain.tld"
+            " -P password123"
+            " --name mycluster"
+            " --category 'custom_thing'"
+            " --tag 'hello world'"
+            " --object-type ClusterComputeResource"
+            " --action add\n"
+            "\n"
+        )
+
+    def examples_bulk(self):
+        return (
+            "examples bulk:\n"
+            "  # Bulk tag all VMs in a Cluster\n"
+            "  ./vphere_tagging_cmdb_exclude.py bulk"
+            " -H vsphere.domain.tld"
+            " -U username@domain.tld"
+            " -P password123"
+            " --query-name 'cls1.dev1'"
+            " --query-object-type 'ClusterComputeResource'"
+            " --bulk-object-type VirtualMachine"
+            " --action add\n"
+            "\n"
+        )
+
+
+if __name__ == "__main__":
+    cli = Cli()
+    args = cli.parse()
+
+    client = VmwareTagging(args.hostname, args.username, args.password)
+
+    # login
+    client.login()
+
+    if args.command == 'single':
+        client.tag_single(object_type=args.object_type,
+                          object_name=args.name,
+                          category=args.category,
+                          tag=args.tag,
+                          cardinality=args.cardinality,
+                          action=args.action)
+    elif args.command == 'bulk':
+        client.tag_bulk(query_object_type=args.query_object_type,
+                        query_name=args.query_name,
+                        object_type=args.object_type,
+                        object_name=args.name,
+                        bulk_object_type=args.bulk_object_type,
+                        category=args.category,
+                        tag=args.tag,
+                        cardinality=args.cardinality,
+                        action=args.action)
+    else:
+        raise RuntimeError("Unkown command: {}".format(args.command))

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.15.1
+version: 0.16.0
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,6 @@
+mock>=1.3.0,<2.0
+unittest2>=1.1.0,<2.0
+nose>=1.3.7
+eventlet==0.25.1
+requests[security]==2.23.0
+pytz==2019.1

--- a/tests/test_action_tag_attach_bulk.py
+++ b/tests/test_action_tag_attach_bulk.py
@@ -88,7 +88,7 @@ class TagAttachBulkTestCase(VsphereBaseActionTestCase):
                                                    category=category_name,
                                                    tag=tag_name,
                                                    cardinality=category_cardinality,
-                                                   action='add')
+                                                   action='attach')
 
     @mock.patch("vmwarelib.actions.BaseAction.connect_rest")
     def test_run_replace(self, mock_connect):

--- a/tests/test_action_tag_attach_bulk.py
+++ b/tests/test_action_tag_attach_bulk.py
@@ -1,0 +1,155 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+
+from tag_attach_bulk import TagAttachBulk
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'TagAttachBulkTestCase'
+]
+
+
+class TagAttachBulkTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = TagAttachBulk
+
+    @mock.patch("vmwarelib.actions.BaseAction.connect_rest")
+    def test_run(self, mock_connect):
+        action = self.get_action_instance(self.new_config)
+
+        # define test variables
+        bulk_object_type = "VirtualMachine"
+        category_name = "cat_name"
+        category_description = "Test Description"
+        category_cardinality = "SINGLE"
+        category_types = []
+        query_object_type = "VirtualMachine"
+        query_object_name = "vm-123"
+        replace = False
+        tag_name = "tag_name"
+        tag_description = "Test Description"
+        vsphere = "default"
+
+        test_kwargs = {
+            "bulk_object_type": bulk_object_type,
+            "category_name": category_name,
+            "category_description": category_description,
+            "category_cardinality": category_cardinality,
+            "category_types": category_types,
+            "query_object_type": query_object_type,
+            "query_object_name": query_object_name,
+            "replace": replace,
+            "tag_name": tag_name,
+            "tag_description": tag_description,
+            "vsphere": vsphere
+        }
+        test_category_id = "123"
+        test_tag_id = "987"
+
+        expected_result = "result"
+
+        # mock
+        action.tagging = mock.MagicMock()
+        action.tagging.category_get_or_create.return_value = {'id': test_category_id}
+
+        expected_result = "result"
+        action.tagging.tag_get_or_create.return_value = {'id': test_tag_id}
+
+        action.tagging.tag_bulk.return_value = expected_result
+
+        # invoke action with valid parameters
+        result = action.run(**test_kwargs)
+
+        self.assertEqual(result, expected_result)
+        mock_connect.assert_called_with(vsphere)
+        action.tagging.category_get_or_create.assert_called_with(category_name,
+                                                                 category_description,
+                                                                 category_cardinality,
+                                                                 category_types)
+        action.tagging.tag_get_or_create.assert_called_with(tag_name,
+                                                            test_category_id,
+                                                            tag_description)
+        action.tagging.tag_bulk.assert_called_with(query_object_type=query_object_type,
+                                                   query_object_name=query_object_name,
+                                                   bulk_object_type=bulk_object_type,
+                                                   category=category_name,
+                                                   tag=tag_name,
+                                                   cardinality=category_cardinality,
+                                                   action='add')
+
+    @mock.patch("vmwarelib.actions.BaseAction.connect_rest")
+    def test_run_replace(self, mock_connect):
+        action = self.get_action_instance(self.new_config)
+
+        # define test variables
+        bulk_object_type = "VirtualMachine"
+        category_name = "cat_name"
+        category_description = "Test Description"
+        category_cardinality = "SINGLE"
+        category_types = []
+        query_object_type = "VirtualMachine"
+        query_object_name = "vm-123"
+        replace = True
+        tag_name = "tag_name"
+        tag_description = "Test Description"
+        vsphere = "default"
+
+        test_kwargs = {
+            "bulk_object_type": bulk_object_type,
+            "category_name": category_name,
+            "category_description": category_description,
+            "category_cardinality": category_cardinality,
+            "category_types": category_types,
+            "query_object_type": query_object_type,
+            "query_object_name": query_object_name,
+            "replace": replace,
+            "tag_name": tag_name,
+            "tag_description": tag_description,
+            "vsphere": vsphere
+        }
+        test_category_id = "123"
+        test_tag_id = "987"
+
+        expected_result = "result"
+
+        # mock
+        action.tagging = mock.MagicMock()
+        action.tagging.category_get_or_create.return_value = {'id': test_category_id}
+
+        expected_result = "result"
+        action.tagging.tag_get_or_create.return_value = {'id': test_tag_id}
+
+        action.tagging.tag_bulk.return_value = expected_result
+
+        # invoke action with valid parameters
+        result = action.run(**test_kwargs)
+
+        self.assertEqual(result, expected_result)
+        mock_connect.assert_called_with(vsphere)
+        action.tagging.category_get_or_create.assert_called_with(category_name,
+                                                                 category_description,
+                                                                 category_cardinality,
+                                                                 category_types)
+        action.tagging.tag_get_or_create.assert_called_with(tag_name,
+                                                            test_category_id,
+                                                            tag_description)
+        action.tagging.tag_bulk.assert_called_with(query_object_type=query_object_type,
+                                                   query_object_name=query_object_name,
+                                                   bulk_object_type=bulk_object_type,
+                                                   category=category_name,
+                                                   tag=tag_name,
+                                                   cardinality=category_cardinality,
+                                                   action='replace')

--- a/tests/test_action_tag_category_list.py
+++ b/tests/test_action_tag_category_list.py
@@ -45,5 +45,5 @@ class CategoryListTestCase(VsphereBaseActionTestCase):
         result = action.run(**test_kwargs)
 
         self.assertEqual(result, expected_result)
-        action.tagging.category_list.assert_called()
+        action.tagging.category_list.assert_called_with()
         mock_connect.assert_called_with(vsphere)

--- a/tests/test_action_tag_detach_bulk.py
+++ b/tests/test_action_tag_detach_bulk.py
@@ -1,0 +1,78 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+
+from tag_detach_bulk import TagDetachBulk
+from vsphere_base_action_test_case import VsphereBaseActionTestCase
+
+__all__ = [
+    'TagDetachBulkTestCase'
+]
+
+
+class TagDetachBulkTestCase(VsphereBaseActionTestCase):
+    __test__ = True
+    action_cls = TagDetachBulk
+
+    @mock.patch("vmwarelib.actions.BaseAction.connect_rest")
+    def test_run(self, mock_connect):
+        action = self.get_action_instance(self.new_config)
+
+        # define test variables
+        bulk_object_type = "VirtualMachine"
+        category_name = "cat_name"
+        category_cardinality = "MULTIPLE"
+        query_object_type = "VirtualMachine"
+        query_object_name = "vm-123"
+        tag_name = "tag_name"
+        vsphere = "default"
+
+        test_kwargs = {
+            "bulk_object_type": bulk_object_type,
+            "category_name": category_name,
+            "category_cardinality": category_cardinality,
+            "query_object_type": query_object_type,
+            "query_object_name": query_object_name,
+            "tag_name": tag_name,
+            "vsphere": vsphere
+        }
+        test_category_id = "123"
+        test_tag_id = "987"
+
+        expected_result = "result"
+
+        # mock
+        action.tagging = mock.MagicMock()
+        action.tagging.category_find_by_name.return_value = {'id': test_category_id}
+
+        expected_result = "result"
+        action.tagging.tag_find_by_name.return_value = {'id': test_tag_id}
+
+        action.tagging.tag_bulk.return_value = expected_result
+
+        # invoke action with valid parameters
+        result = action.run(**test_kwargs)
+
+        self.assertEqual(result, expected_result)
+        mock_connect.assert_called_with(vsphere)
+        action.tagging.category_find_by_name.assert_called_with(category_name)
+        action.tagging.tag_find_by_name.assert_called_with(tag_name, "123")
+        action.tagging.tag_bulk.assert_called_with(query_object_type=query_object_type,
+                                                   query_object_name=query_object_name,
+                                                   bulk_object_type=bulk_object_type,
+                                                   category=category_name,
+                                                   tag=tag_name,
+                                                   cardinality=category_cardinality,
+                                                   action='detach')


### PR DESCRIPTION
Additions:
* Added lots of new back-end API functionality to the `vmwarelib.tagging.VmwareTagging` interface.
* Added new `vsphere.tag_attach_bulk` action to attach a tag to a bulk set of resources.
  Primary usecase is tagging all VMs in a cluster dynamically.
* Added new `vsphere.tag_detach_bulk` action to detach a tag from a bulk set of resources.
  Primary usecase is remoave a tag from all VMs in a cluster dynamically.
