### PR TITLE
Fixed bug in bulk tagging where empty bulk results were throwing an error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.16.1
+
+Fixes:
+* Fixed bug in `vsphere.tag_*_bulk` where it was erroring if it found no bulk objects
+  under the query object (example if a Cluster had no VMs in it).
+
+Contributed by Nick Maludy (@nmaludy Encore Technologies).
+
 ## v0.16.0
 
 Additions:

--- a/actions/vmwarelib/tagging.py
+++ b/actions/vmwarelib/tagging.py
@@ -360,6 +360,7 @@ class VmwareTagging(object):
         return obj_id
 
     def object_list_validate_single_element(self, object_list, object_type, params):
+        self.object_list_raise_if_empty(object_list, object_type, params)
         if len(object_list) > 1:
             filter_name, filter_value = self.filter_name_value(params)
             raise ValueError(("Sorry, we found >1 object matching this name in vCenter: "
@@ -367,6 +368,14 @@ class VmwareTagging(object):
                                                                         filter_name,
                                                                         filter_value,
                                                                         object_list))
+
+    def object_list_raise_if_empty(self, value, object_type, params):
+        if len(value) == 0:
+            filter_name, filter_value = self.filter_name_value(params)
+            raise ValueError(("Sorry we couldn't find the object you asked for in vCenter: "
+                              "object_type={} {}={}").format(object_type,
+                                                             filter_name,
+                                                             filter_value))
 
     def object_extract_id(self, obj, object_type, params):
         id_key = self.object_type_id_key(object_type)
@@ -436,13 +445,6 @@ class VmwareTagging(object):
                              " it is a type={} response={}"
                              .format(type(response['value']),
                                      response))
-
-        if len(value) == 0:
-            filter_name, filter_value = self.filter_name_value(params)
-            raise ValueError(("Sorry we couldn't find the object you asked for in vCenter: "
-                              "object_type={} {}={}").format(object_type,
-                                                             filter_name,
-                                                             filter_value))
         return value
 
     def cluster_find(self, params=None):

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 0.16.0
+version: 0.16.1
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:


### PR DESCRIPTION
In the new bulk tagging actions, if the query object return an empty list of results, the tagging action would fail (example if the Cluster contained no VMs).

This fix allows for the query object to return an empty list, because empty clusters, etc are totally valid configurations.