### PR TITLE
Add error handler or log error instead of using "continue" on exception in vSphere

### DIFF
--- a/actions/vm_snapshots_delete.py
+++ b/actions/vm_snapshots_delete.py
@@ -74,8 +74,8 @@ class VMSnapshotsDelete(BaseAction):
             # Check if any snapshots exist on the VM
             try:
                 snapshots = vm.snapshot.rootSnapshotList
-            except:
-                continue
+            except Exception as e:
+                print(f'No snapshots found for VM. {e}')
 
             result = self.delete_old_snapshots(snapshots, max_age_days, name_ignore_patterns)
             # Append the results from each VM

--- a/actions/vm_snapshots_delete.py
+++ b/actions/vm_snapshots_delete.py
@@ -74,10 +74,11 @@ class VMSnapshotsDelete(BaseAction):
             # Check if any snapshots exist on the VM
             try:
                 snapshots = vm.snapshot.rootSnapshotList
-            except Exception as e:
-                print(f'No snapshots found for VM. {e}')
+            except Exception:
+                self.logger.exception(f'No snapshots found for VM.')
 
             result = self.delete_old_snapshots(snapshots, max_age_days, name_ignore_patterns)
+
             # Append the results from each VM
             deleted_snapshots += result['deleted_snapshots']
             ignored_snapshots += result['ignored_snapshots']


### PR DESCRIPTION
Replace the continue statement with explicit error logs. The pass/continue statement when run in production (non-debug) code will skip the error. We want to practice safe coding so exception handling is necessary.