### PR TITLE
Add error handler or log error instead of using "continue" on exception in vSphere

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v1.0.1
+
+Addition:
+*  `vm_snapshots_delete` - Replaced continue statement with exception handling which is necessary so that error will not be skipped when run in production (non-debug).
+
 ## v1.0.0
 
 * Drop Python 2.7 support

--- a/actions/vm_snapshots_delete.py
+++ b/actions/vm_snapshots_delete.py
@@ -75,7 +75,7 @@ class VMSnapshotsDelete(BaseAction):
             try:
                 snapshots = vm.snapshot.rootSnapshotList
             except:
-                continue
+                self.logger.exception(f'No snapshots found for VM.')
 
             result = self.delete_old_snapshots(snapshots, max_age_days, name_ignore_patterns)
             # Append the results from each VM

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 1.0.0
+version: 1.0.1
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:


### PR DESCRIPTION
Replace the continue statement with explicit error logs. The pass/continue statement when run in production (non-debug) code will skip the error. We want to practice safe coding so exception handling is necessary.