### PR TITLE
update/change-get_vms-to-return-all-mathing-ids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v1.2.0
+
+Changed action:
+* `vsphere.get_vms` - Added option to get VMs with a list of UUIDs. Also changed MOID lookup to loop through all VMs instead of returning the first one in case any duplicates were found
+
 ## v1.1.0
 
 Fixes:

--- a/actions/get_vms.yaml
+++ b/actions/get_vms.yaml
@@ -7,11 +7,15 @@
     parameters:
         ids:
             type: 'array'
-            description: Comma-separated ids of Virtual Machines to retrieve.
+            description: Comma-separated moids of Virtual Machines to retrieve.
             required: false
         names:
             type: 'array'
             description: Comma-separated names of Virtual Machines to retrieve.
+            required: false
+        uuids:
+            type: 'array'
+            description: Comma-separated uuids of Virtual Machines to retrieve.
             required: false
         datastores:
             type: 'array'

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@ ref: vsphere
 name: vsphere
 description: VMware vSphere
 stackstorm_version: ">=2.9.0"
-version: 1.1.0
+version: 1.2.0
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:


### PR DESCRIPTION
Added option to get VMs by UUID as well as MOID and name. Also updated get by MOID action to work the same as get by name and return all VMs with the matching ID instead of just the first one because we found that it's possible for a VM to have a duplicate MOID if it has been restored from a backup.